### PR TITLE
refactor: Update Input File Writing Scheme

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -1,0 +1,38 @@
+name: install_and_test
+
+on:
+  push:
+    branches:
+      - main
+      - "release/**"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  install_and_import:
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y libgdal-dev
+
+      - name: Install pytRIBS
+        run: pip install -e .
+
+      - name: Smoke test import
+        run: python -c "import pytRIBS; print('pytRIBS imported successfully')"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pytRIBS.egg-info
 /temp.py
 /test/
 /testing_get_met.py
+.venv

--- a/README.md
+++ b/README.md
@@ -15,16 +15,25 @@ A full tRIBS model setup, simulation, and analysis is provided [here.](https://z
 PytRIBS uses semantic versioning. Currently, we are in the initial development phase--anything MAY change at any time and
 this package SHOULD NOT be considered stable.
 
-## Version 0.7.1 (02/03/2026)
+## Version 0.7.2 (04/02/2026)
+This release fixes an issue users on certain versions of Python and introduces GitHub Actions.
+
+#### Added
+* Added GitHub Actions workflow to verify installation across Python 3.10, 3.11, and 3.12 on ubuntu-latest.
+
+#### Changed
+* Relaxed `earthaccess` requirement from `~=0.15.1` to `>=0.14.0` to resolve a dependency conflict for users on Python 3.10.
+
+### Version 0.7.1 (02/03/2026)
 This release is a small update to add a missing dependency required for downloading and processing the NLDAS-2 elevation raster.
 
 ### Version 0.7.0 (02/03/2026)
 This release introduces a set of relatively small changes that fix existing points of confusion or bugs in the code. Additionally, updates to the meteorological workflow to handle changes to the NASA API for downloading NLDAS-2 data.
 
-### Added
+#### Added
 * Added new optional input to the run_soil_workflow for downloading POLARIS gridded soil data rather than the ISRIC dataset. Can be controlled with the `source` argument but defaults to ISRIC if not specified. This dataset follows the same general workflow but does not require applying ROSETTA3 like with the ISRIC data. ([#26](https://github.com/tRIBS-Model/pytRIBS/pull/26))
 
-### Changed / Improved
+#### Changed / Improved
 * **Spatial Outputs** ([#28](https://github.com/tRIBS-Model/pytRIBS/pull/28))
     * Addressed limitation of pytRIBS workflow only able to process tRIBS spatial outputs if the model was ran in parallel mode.
     * Renamed merge_parallel_spatial_files to get_spatial_files to reflect its expanded capability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = {text = "GPL-version 2"}
 keywords = ["hydrology","modeling"]
 dependencies = [
     "docker~=7.1.0",
-    "earthaccess~=0.15.1",
+    "earthaccess>=0.14.0",
     "geopandas~=0.14.4",
     "matplotlib-scalebar~=0.9.0",
     "matplotlib>=3.9.0",
@@ -37,7 +37,7 @@ dependencies = [
     "xarray~=2025.4.0",
     "h5py~=3.15.1",
 ]
-version = "0.7.1"
+version = "0.7.2"
 
 [project.urls]
 Repository = "https://github.com/tribshms/pytRIBS"

--- a/pytRIBS/classes.py
+++ b/pytRIBS/classes.py
@@ -402,18 +402,12 @@ class Met(MetProcessor):
         The path or name of the file containing hydrometeorological station data.
     gaugestations : str
         The path or name of the file containing gauge station data.
-    hydrometbasename : str
-        The base name for hydrometeorological data files.
     rainfile : str
         The path or name of the file containing rainfall data.
     hydrometgrid : str
         The path or name of the file containing the hydrometeorological grid data.
-    metdataoption : int
-        Option flag for meteorological data processing.
     rainsource : str
         The source of the rainfall data.
-    gaugebasename : str
-        The base name for gauge data files.
     rainextension : str
         The file extension for the rainfall data files.
     """
@@ -432,10 +426,7 @@ class Met(MetProcessor):
 
         self.hydrometstations = options['hydrometstations']
         self.gaugestations = options['gaugestations']
-        self.hydrometbasename = options['hydrometbasename']
         self.rainfile = options['rainfile']
         self.hydrometgrid = options['hydrometgrid']
-        self.metdataoption = options['metdataoption']
         self.rainsource = options['rainsource']
-        self.gaugebasename = options['gaugebasename']
         self.rainextension = options['rainextension']

--- a/pytRIBS/shared/infile_mixin.py
+++ b/pytRIBS/shared/infile_mixin.py
@@ -24,9 +24,11 @@ class Infile:
         meterological    -  options for meterological data
         output    - options and paths for model outputs
         forecast - suite of options for forecast mode
-        stochastic    - suite of options for stochastic mode
         restart   - options for restart functionality
         parallel  - options for parallel functionality
+
+        Section/subsection fields organize how write_input_file groups and formats output.
+        Entries without a section field are written at the end under "Additional Options".
         """
         input_file = {
 
@@ -35,328 +37,306 @@ class Infile:
             # ==================================================================================================
 
             "startdate": {"keyword": "STARTDATE:", "describe": "Starting time (MM/DD/YYYY/HH/MM)", "value": None,
-                          "tags": ["time"]},
+                          "tags": ["time"], "section": 1, "subsection": "Time Variables"},
             "runtime": {"keyword": "RUNTIME:", "describe": "Simulation length in hours", "value": None,
-                        "tags": ["time"]},
-            "rainsearch": {"keyword": "RAINSEARCH:", "describe": "Rainfall search interval (hours)", "value": 24,
-                           "tags": ["time"]},
+                        "tags": ["time"], "section": 1, "subsection": "Time Variables"},
             "timestep": {"keyword": "TIMESTEP:", "describe": "Unsaturated zone computational time step (mins)",
-                         "value": 3.75, "tags": ["time"]},
+                         "value": 3.75, "tags": ["time"], "section": 1, "subsection": "Time Variables"},
             "gwstep": {"keyword": "GWSTEP:", "describe": "Saturated zone computational time step (mins)",
-                       "value": 30.0, "tags": ["time"]},
+                       "value": 30.0, "tags": ["time"], "section": 1, "subsection": "Time Variables"},
             "metstep": {"keyword": "METSTEP:", "describe": "Meteorological data time step (mins)", "value": 60.0,
-                        "tags": ["time"]},
-            "etistep": {"keyword": "ETISTEP:", "describe": "ET, interception and snow time step (hours)", "value": 1,
-                        "tags": ["time"]},
+                        "tags": ["time"], "section": 1, "subsection": "Time Variables"},
             "rainintrvl": {"keyword": "RAININTRVL:", "describe": "Time interval in rainfall input (hours)",
-                           "value": 1, "tags": ["time"]},
-            "intstormmax": {"keyword": "INTSTORMMAX:", "describe": "Interstorm interval (hours)", "value": 10000,
-                            "tags": ["time"]},
-            # ==================================================================================================
-            # MESH PARAMETERS
-            # ==================================================================================================
-            "optmeshinput": {"keyword": "OPTMESHINPUT:", "describe": "Mesh input data option\n" + \
-                                                                      "1  tMesh data\n" + \
-                                                                      "2  Point file\n" + \
-                                                                      "3  ArcGrid (random)\n" + \
-                                                                      "4  ArcGrid (hex)\n" + \
-                                                                      "5  Arc/Info *.net\n" + \
-                                                                      "6  Arc/Info *.lin,*.pnt\n" + \
-                                                                      "7  Scratch\n" + \
-                                                                      "8  Point Triangulator", "value": 8,
-                             "tags": ["mesh"]},
-            "inputdatafile": {"keyword": "INPUTDATAFILE:", "describe": "tMesh input file base name for Mesh files",
-                              "value": None, "tags": ["mesh"]},
-            "inputtime": {"keyword": "INPUTTIME:", "describe": "Deprecated, will be removed", "value": None, "tags": ["mesh"]},
-            "arcinfofilename": {"keyword": "ARCINFOFILENAME:", "describe": "tMesh input file base name Arc files",
-                                "value": None, "tags": ["mesh"]},
-            "pointfilename": {"keyword": "POINTFILENAME:", "describe": "tMesh input file name Points files",
-                              "value": None, "tags": ["mesh"]},
+                           "value": 1, "tags": ["time"], "section": 1, "subsection": "Time Variables"},
+            "opintrvl": {"keyword": "OPINTRVL:", "describe": "Output interval (hours)", "value": 1,
+                         "tags": ["output"], "section": 1, "subsection": "Time Variables"},
+            "spopintrvl": {"keyword": "SPOPINTRVL:", "describe": "Spatial output interval (hours)", "value": 8760,
+                           "tags": ["output"], "section": 1, "subsection": "Time Variables"},
+            "intstormmax": {"keyword": "INTSTORMMAX:", "describe": "Interstorm interval (hours)", "value": 50,
+                            "tags": ["time"], "section": 1, "subsection": "Time Variables"},
+            "rainsearch": {"keyword": "RAINSEARCH:", "describe": "Rainfall search interval (hours)", "value": 24,
+                           "tags": ["time"], "section": 1, "subsection": "Time Variables"},
+
             # ==================================================================================================
             # ROUTING PARAMETERS
             # ==================================================================================================
 
             "baseflow": {"keyword": "BASEFLOW:", "describe": "Baseflow discharge (m3/s)", "value": 0.2,
-                         "tags": ["flow"]},
-            "velocitycoef": {"keyword": "VELOCITYCOEF:", "describe": "Discharge-velocity coefficient", "value": 1.2,
-                             "tags": ["flow"]},
+                         "tags": ["flow"], "section": 1, "subsection": "Routing Variables"},
             "kinemvelcoef": {"keyword": "KINEMVELCOEF:", "describe": "Kinematic routing velocity coefficient",
-                             "value": 3, "tags": ["flow"]},
-            "velocityratio": {"keyword": "VELOCITYRATIO:", "describe": "Stream to hillslope velocity coefficient",
-                              "value": 60, "tags": ["flow"]},
+                             "value": 3, "tags": ["flow"], "section": 1, "subsection": "Routing Variables"},
             "flowexp": {"keyword": "FLOWEXP:", "describe": "Nonlinear discharge coefficient", "value": 0.3,
-                        "tags": ["flow"]},
+                        "tags": ["flow"], "section": 1, "subsection": "Routing Variables"},
             "channelroughness": {"keyword": "CHANNELROUGHNESS:", "describe": "Uniform channel roughness value",
-                                 "value": 0.15, "tags": ["flow"]},
+                                 "value": 0.15, "tags": ["flow"], "section": 1, "subsection": "Routing Variables"},
             "channelwidth": {"keyword": "CHANNELWIDTH:", "describe": "Uniform channel width  (meters)", "value": 12,
-                             "tags": ["flow"]},
+                             "tags": ["flow"], "section": 1, "subsection": "Routing Variables"},
             "channelwidthcoeff": {"keyword": "CHANNELWIDTHCOEFF:",
                                   "describe": "Coefficient in width-area relationship", "value": 2.33,
-                                  "tags": ["flow"]},
+                                  "tags": ["flow"], "section": 1, "subsection": "Routing Variables"},
             "channelwidthexpnt": {"keyword": "CHANNELWIDTHEXPNT:", "describe": "Exponent in width-area relationship",
-                                  "value": 0.54, "tags": ["flow"]},
+                                  "value": 0.54, "tags": ["flow"], "section": 1, "subsection": "Routing Variables"},
             "channelwidthfile": {"keyword": "CHANNELWIDTHFILE:", "describe": "Filename that contains channel widths",
-                                 "value": None, "tags": ["flow"]},
-            "widthinterpolation": {"keyword": "WIDTHINTERPOLATION:",
-                                   "describe": "Option for interpolating width values", "value": 0, "tags": ["flow"]},
+                                 "value": None, "tags": ["flow"], "section": 1, "subsection": "Routing Variables"},
 
             # ==================================================================================================
-            # HYDROLOGIC PARAMETERS
+            # MODEL RUN OPTIONS
             # ==================================================================================================
 
-            "optevapotrans": {"keyword": "OPTEVAPOTRANS:", "describe": "Option for evapoTranspiration scheme\n" + \
-                                                                        "0  Inactive evapotranspiration\n" + \
-                                                                        "1  Penman-Monteith method\n" + \
-                                                                        "2  Deardorff method\n" + \
-                                                                        "3  Priestley-Taylor method\n" + \
-                                                                        "4  Pan evaporation measurements", "value": 1,
-                              "tags": ["hydro"]},
-            "optintercept": {"keyword": "OPTINTERCEPT:", "describe": "Option for interception scheme\n" + \
-                                                                      "0  Inactive interception\n" + \
-                                                                      "1  Canopy storage method\n" + \
-                                                                      "2  Canopy water balance method", "value": 2,
-                             "tags": ["hydro"]},
-            "optlanduse": {"keyword": "OPTLANDUSE:", "describe": "Option for static or dynamic land cover\n" + \
-                                                                  "0  Static land cover maps\n" + \
-                                                                  "1  Dynamic updating of land cover maps", "value": 0,
-                           "tags": ["hydro"]},
-            "optluinterp": {"keyword": "OPTLUINTERP:", "describe": "Option for interpolation of land cover\n" + \
-                                                                    "0  Constant (previous) values between land cover\n" + \
-                                                                    "1  Linear interpolation between land cover",
-                            "value": 0, "tags": ["hydro"]},
-            "optsoiltype": {"keyword": "OPTSOILTYPE:", "describe": "Option for soil input type: 0 soil table, 1 soil "
-                                                                    "rasters\n See SCGRID, SOILTABLENAME, and SOILMAPNAME",
-                            "value": 0, "tags": ["hydro"]},
-            "gfluxoption": {"keyword": "GFLUXOPTION:", "describe": "Option for ground heat flux\n" + \
-                                                                    "0  Inactive ground heat flux\n" + \
-                                                                    "1  Temperature gradient method\n" + \
-                                                                    "2  Force_Restore method", "value": 2,
-                             "tags": ["hydro"]},
-            "optbedrock": {"keyword": "OPTBEDROCK:", "describe": "Option for uniform or variable depth\n"
-                                                                  "0 Uniform bedrock depth\n"
-                                                                  "1 Spatial grid of bedrock depth\n"
-                                                                  "See DEPTHTOBEDROCK and BEDROCKFILE\n", "value": 0,
-                           "tags": ["hydro"]},
-            "optgroundwater": {"keyword": "OPTGROUNDWATER","describe": "Option for groundwater module, 0 off, 1 on",
-                                "value": 1, "tags": ['hydro']},
+            "optmeshinput": {"keyword": "OPTMESHINPUT:", "describe": ("Mesh input data option\n"
+                                                                     "1  tMesh data\n"
+                                                                     "2  Point Triangulator"),
+                             "value": 2, "tags": ["mesh"], "section": 2},
 
-            "optgwfile": {"keyword": "OPTGWFILE:", "describe": "Option for groundwater initial file\n" + \
-                                                                "0 Resample ASCII grid file in GWATERFILE\n" + \
-                                                                "1 Read in Voronoi polygon file with GW levels",
-                          "value": 0, "tags": ["hydro"]},
+            "rainsource": {"keyword": "RAINSOURCE:", "describe": ("Rainfall data source option\n"
+                                                                   "1  Gridded Rainfall\n"
+                                                                   "2  Rain gauges"),
+                           "value": 2, "tags": ["meterological"], "section": 2},
 
-            "optrunon": {"keyword": "OPTRUNON:", "describe": "Option for runon in overland flow paths [IN DEVELOPMENT]: 0 off, 1 on", "value": 0,
-                         "tags": ["hydro"]},
-            "optreservoir": {"keyword": "OPTRESERVOIR:", "describe": 'Option for leve pool routing: 0 off, 1 on',
-                             "value": 0, "tags": ["hydro"]},
-            ### added
-            "respolygonid": {"keyword": "RESPOLYGONID:", "describe": "Path to file of node IDs representing reservoirs",
-                             "value":None, "tags": ["hydro"]},
-            "resdata": {"keyword": "RESDATA:", "describe": "Path to file of elevation-discharge-storage information for each type of reservoir",
-                        "value":None,"tags": ["hydro"]},
+            "optevapotrans": {"keyword": "OPTEVAPOTRANS:", "describe": ("Option for evapoTranspiration scheme\n"
+                                                                        "0  Inactive evapotranspiration\n"
+                                                                        "1  Penman-Monteith method\n"
+                                                                        "2  Pan evaporation measurements"),
+                              "value": 1, "tags": ["hydro"], "section": 2},
 
-            "optsnow": {"keyword": "OPTSNOW:", "describe": "Enable single layer snow module : 0 off, 1 on", "value": 1,
-                        "tags": ["hydro"]},
-            "minsntemp": {"keyword": "MINSNTEMP:", "describe": "Minimum snow temperature", "value": -50.0,
-                          "tags": ["hydro"]},
-            "snliqfrac": {"keyword": "SNLIQFRAC:", "describe": "Maximum fraction of liquid water in snowpack",
-                          "value": 0.065, "tags": ["hydro"]},
-            "depthtobedrock": {"keyword": "DEPTHTOBEDROCK:", "describe": "Uniform depth to bedrock (meters), see OPTBEDROCK",
-                               "value": 15, "tags": ["hydro"]},
-            "optpercolation": {"keyword": "OPTPERCOLATION:", "describe": "Option to for percolation losses from channels\n"
-                               "0 off\n1 on"
+            "optsnow": {"keyword": "OPTSNOW:", "describe": ("Option for snow module\n"
+                                                            "0  Inactive snow module\n"
+                                                            "1  Single layer snow module"),
+                        "value": 1, "tags": ["hydro"], "section": 2},
 
-                , "value": 0,
-                               "tags": ["hydro"]},
-            "channelconductivity": {"keyword": "CHANNELCONDUCTIVITY:", "describe": "Conductivity in channel", "value": 0,
-                                    "tags": ["hydro"]},
-            "transientconductivity": {"keyword": "TRANSIENTCONDUCTIVITY:", "describe": "Conductivity during transient period",
-                                      "value": 0, "tags": ["hydro"]},
-            "transienttime": {"keyword": "TRANSIENTTIME:", "describe": "Time until transient period ends", "value": 0,
-                              "tags": ["hydro"]},
-            "channelporosity": {"keyword": "CHANNELPOROSITY:", "describe": "Porosity in channel", "value": 0,
-                                "tags": ["hydro"]},
-            "chanporeindex": {"keyword": "CHANPOREINDEX:", "describe": "Channel pore index in channel", "value": 0,
-                              "tags": ["hydro"]},
-            "chanpsib": {"keyword": "CHANPSIB:", "describe": "Matric potential in channel", "value": 0, "tags": ["hydro"]},
+            "hillalbopt": {"keyword": "HILLALBOPT:", "describe": ("Option for albedo of surrounding hillslopes\n"
+                                                                  "0  Snow albedo for hillslopes\n"
+                                                                  "1  Land-cover albedo for hillslopes\n"
+                                                                  "2  Dynamic albedo for hillslopes"),
+                           "value": 0, "tags": ["meterological"], "section": 2},
+
+            "optradshelt": {"keyword": "OPTRADSHELT:", "describe": ("Option for local and remote radiation sheltering\n"
+                                                                    "0  Local controls on shortwave radiation\n"
+                                                                    "1  Remote controls on diffuse shortwave\n"
+                                                                    "2  Remote controls on entire shortwave\n"
+                                                                    "3  No sheltering"),
+                            "value": 0, "tags": ["meterological"], "section": 2},
+
+            "optintercept": {"keyword": "OPTINTERCEPT:", "describe": ("Option for interception scheme\n"
+                                                                      "0  Inactive interception\n"
+                                                                      "1  Canopy water balance method"),
+                             "value": 1, "tags": ["hydro"], "section": 2},
+
+            "optlanduse": {"keyword": "OPTLANDUSE:", "describe": ("Option for static or dynamic land cover\n"
+                                                                  "0  ID Map with Lookup Table (LANDTABLENAME, LANDMAPNAME)\n"
+                                                                  "1  Dynamic updating of gridded parameter maps, ID Map & Table for non-gridded parameters (LUGRID)\n"
+                                                                  "2  Static gridded parameter maps, ID Map & Table for non-gridded parameters (LUGRID)"),
+                           "value": 0, "tags": ["hydro"], "section": 2},
+
+            "optluinterp": {"keyword": "OPTLUINTERP:", "describe": ("Option for interpolation of land cover\n"
+                                                                    "0  Constant (previous) values between land cover\n"
+                                                                    "1  Linear interpolation between land cover"),
+                            "value": 0, "tags": ["hydro"], "section": 2},
+
+            "gfluxoption": {"keyword": "GFLUXOPTION:", "describe": ("Option for ground heat flux\n"
+                                                                    "0  Inactive ground heat flux\n"
+                                                                    "1  Temperature gradient method\n"
+                                                                    "2  Force-Restore method"),
+                            "value": 2, "tags": ["hydro"], "section": 2},
+
+            "metdataoption": {"keyword": "METDATAOPTION:", "describe": ("Option for meteorological data\n"
+                                                                        "0  Inactive meteorological data\n"
+                                                                        "1  Weather station point data\n"
+                                                                        "2  Gridded meteorological data"),
+                              "value": 1, "tags": ["meterological"], "section": 2},
+
+            "optbedrock": {"keyword": "OPTBEDROCK:", "describe": ("Option for uniform or variable depth\n"
+                                                                  "0  Uniform bedrock depth (DEPTHTOBEDROCK)\n"
+                                                                  "1  Spatial grid of bedrock depth (BEDROCKFILE)"),
+                           "value": 0, "tags": ["hydro"], "section": 2},
+
+            "widthinterpolation": {"keyword": "WIDTHINTERPOLATION:", "describe": ("Option for interpolating width values\n"
+                                                                                  "0  Interpolate between measured and observed\n"
+                                                                                  "1  Interpolate only between measured"),
+                                   "value": 0, "tags": ["flow"], "section": 2},
+
+            "optgwfile": {"keyword": "OPTGWFILE:", "describe": ("Option for groundwater initial file\n"
+                                                                "0  Resample ASCII grid file in GWATERFILE\n"
+                                                                "1  Read in Voronoi polygon file with GW levels"),
+                          "value": 0, "tags": ["hydro"], "section": 2},
+
+            "optgroundwater": {"keyword": "OPTGROUNDWATER:", "describe": ("Option for groundwater module\n"
+                                                                          "0  Inactive groundwater module\n"
+                                                                          "1  Active groundwater module"),
+                               "value": 1, "tags": ["hydro"], "section": 2},
+
+            "optspatial": {"keyword": "OPTSPATIAL:", "describe": ("Option for writing spatial outputs\n"
+                                                                  "0  Inactive spatial outputs\n"
+                                                                  "1  Active spatial outputs at interval SPOPINTRVL"),
+                           "value": 1, "tags": ["hydro"], "section": 2},
+
+            "optrunon": {"keyword": "OPTRUNON:", "describe": ("Option for runon in overland flow paths\n"
+                                                              "0  Inactive runon module\n"
+                                                              "1  Active runon module [IN DEVELOPMENT]"),
+                         "value": 0, "tags": ["hydro"], "section": 2},
+
+            "optreservoir": {"keyword": "OPTRESERVOIR:", "describe": ("Option for level pool reservoir routing\n"
+                                                                      "0  Inactive reservoir routing module\n"
+                                                                      "1  Active level pool reservoir routing module"),
+                             "value": 0, "tags": ["hydro"], "section": 2},
+
+            "optsoiltype": {"keyword": "OPTSOILTYPE:", "describe": ("Option for soil input type\n"
+                                                                    "0  ID Map with Lookup Table (SOILTABLENAME, SOILMAPNAME)\n"
+                                                                    "1  Static gridded parameter maps, ID Map & Table for non-gridded parameters (SCGRID)"),
+                            "value": 0, "tags": ["hydro"], "section": 2},
+
+            "optpercolation": {"keyword": "OPTPERCOLATION:", "describe": ("Option for percolation losses from channels\n"
+                                                                          "0  Inactive channel transmission losses\n"
+                                                                          "1  Constant loss method\n"
+                                                                          "2  Transient loss method\n"
+                                                                          "3  Green-Ampt loss method [IN DEVELOPMENT]"),
+                               "value": 0, "tags": ["hydro"], "section": 2},
+
+            # ==================================================================================================
+            # MESH / INPUT FILES
+            # ==================================================================================================
+
+            "inputdatafile": {"keyword": "INPUTDATAFILE:", "describe": "tMesh input file base name for Mesh files",
+                              "value": None, "tags": ["mesh"], "section": 3, "subsection": "Mesh Generation"},
+            "pointfilename": {"keyword": "POINTFILENAME:", "describe": "tMesh input file name Points files",
+                              "value": None, "tags": ["mesh"], "section": 3, "subsection": "Mesh Generation"},
+
             # ==================================================================================================
             # GRID RESAMPLE
             # ==================================================================================================
 
-            "lugrid": {"keyword": "LUGRID:", "describe": "Land cover grid data file (*.gdf)", "value": None,
-                       "tags": ["spatial"]},
-            "scgrid": {"keyword": "SCGRID:", "describe": "Soil grid data file (*.gdf). Note OPTSOILTYPE must = 1 if "
-                                                          "inputing soil grids", "value": None,
-                       "tags": ["spatial"]},
             "soiltablename": {"keyword": "SOILTABLENAME:", "describe": "Soil parameter reference table (*.sdt)",
-                              "value": None, "tags": ["spatial"]},
+                              "value": None, "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
             "soilmapname": {"keyword": "SOILMAPNAME:", "describe": "Soil texture ASCII grid (*.soi)", "value": None,
-                            "tags": ["spatial"]},
+                            "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
             "landtablename": {"keyword": "LANDTABLENAME:", "describe": "Land use parameter reference table",
-                              "value": None, "tags": ["spatial"]},
+                              "value": None, "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
             "landmapname": {"keyword": "LANDMAPNAME:", "describe": "Land use ASCII grid (*.lan)", "value": None,
-                            "tags": ["spatial"]},
+                            "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
             "gwaterfile": {"keyword": "GWATERFILE:", "describe": "Ground water ASCII grid (*iwt)", "value": None,
-                           "tags": ["spatial"]},
-            "bedrockfile": {"keyword": "BEDROCKFILE:", "describe": "Bedrock depth ASCII grid (*.brd), see OPTBEDROCK", "value": None,
-                            "tags": ["spatial"]},
+                           "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
             "demfile": {"keyword": "DEMFILE:", "describe": "DEM ASCII grid for sky and land view factors (*.dem)",
-                        "value": None, "tags": ["spatial"]},
+                        "value": None, "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
+            "rainfile": {"keyword": "RAINFILE:", "describe": "Base name of the radar ASCII grid", "value": None,
+                         "tags": ["meterological"], "section": 3, "subsection": "Resampling Grids"},
+            "rainextension": {"keyword": "RAINEXTENSION:", "describe": "Extension for the radar ASCII grid",
+                              "value": None, "tags": ["meterological"], "section": 3, "subsection": "Resampling Grids"},
+            "depthtobedrock": {"keyword": "DEPTHTOBEDROCK:", "describe": "Uniform depth to bedrock (meters), see OPTBEDROCK",
+                               "value": 15, "tags": ["hydro"], "section": 3, "subsection": "Resampling Grids"},
+            "bedrockfile": {"keyword": "BEDROCKFILE:", "describe": "Bedrock depth ASCII grid (*.brd), see OPTBEDROCK",
+                            "value": None, "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
+            "lugrid": {"keyword": "LUGRID:", "describe": "Land cover grid data file (*.gdf)", "value": None,
+                       "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
+            "scgrid": {"keyword": "SCGRID:", "describe": "Soil cover grid data file (*.gdf)", "value": None,
+                       "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
 
             # ==================================================================================================
             # METEROLOGICAL DATA
             # ==================================================================================================
-            "rainsource": {"keyword": "RAINSOURCE:", "describe": "Rainfall data source option\n" +
-                                                                  "1  Stage III radar\n" +
-                                                                  "2  WSI radar\n" +
-                                                                  "3  Rain gauges", "value": 3, "tags": ["meterological"]},
-            "rainfile": {"keyword": "RAINFILE:", "describe": "Base name of the radar ASCII grid", "value": None,
-                         "tags": ["meterological"]},
-            "rainextension": {"keyword": "RAINEXTENSION:", "describe": "Extension for the radar ASCII grid",
-                              "value": None, "tags": ["meterological"]},
-            "metdataoption": {"keyword": "METDATAOPTION:", "describe": "Option for meteorological data\n" + \
-                                                                        "0  Inactive meteorological data\n" + \
-                                                                        "1  Weather station point data\n" +
-                                                                        "2  Gridded meteorological data", "value": 1,
-                              "tags": ["meterological"]},
-            "hydrometstations": {"keyword": "HYDROMETSTATIONS:",
-                                 "describe": "Hydrometeorological station file (*.sdf)", "value": None, "tags": ["meterological"]},
-            "hydrometgrid": {"keyword": "HYDROMETGRID:", "describe": "Hydrometeorological grid data file (*.gdf)",
-                             "value": None, "tags": ["meterological"]},
-            "hydrometconvert": {"keyword": "HYDROMETCONVERT:",
-                                "describe": "Hydrometeorological data conversion file (*.mdi)", "value": None,
-                                "tags": ["meterological"]},
-            "hydrometbasename": {"keyword": "HYDROMETBASENAME:",
-                                 "describe": "Hydrometeorological data BASE name (*.mdf)", "value": None,
-                                 "tags": ["meterological"]},
-            "gaugestations": {"keyword": "GAUGESTATIONS:", "describe": "Rain Gauge station file (*.sdf)",
-                              "value": None, "tags": ["meterological"]},
-            "gaugeconvert": {"keyword": "GAUGECONVERT:", "describe": "Rain Gauge data conversion file (*.mdi)",
-                             "value": None, "tags": ["meterological"]},
-            "gaugebasename": {"keyword": "GAUGEBASENAME:", "describe": "Rain Gauge data BASE name (*.mdf)",
-                              "value": None, "tags": ["meterological"]},
-            "outhydroextension": {"keyword": "OUTHYDROEXTENSION:", "describe": "Extension for hydrograph output",
-                                  "value": "mrf", "tags": ["meterological"]},
-            "ribshydoutput": {"keyword": "RIBSHYDOUTPUT:", "describe": "Compatibility with RIBS User Interphase,\nDepracted and will be removed.",
-                              "value": 0, "tags": ["meterological"]},
-            "convertdata": {"keyword": "CONVERTDATA:", "describe": "Option to convert met data format", "value": 0,
-                            "tags": ["meterological"]},
-            "templapse": {"keyword": "TEMPLAPSE:", "describe": "Temperature lapse rate", "value": -0.0065,
-                          "tags": ["meterological"]},
-            "preclapse": {"keyword": "PRECLAPSE:", "describe": "Precipitation lapse rate", "value": 0,
-                          "tags": ["meterological"]},
-            "hillalbopt": {"keyword": "HILLALBOPT:", "describe": "Option for albedo of surrounding hillslopes\n" + \
-                                                                  "0  Snow albedo for hillslopes\n" + \
-                                                                  "1  Land-cover albedo for hillslopes\n" + \
-                                                                  "2  Dynamic albedo for hillslopes", "value": 0,
-                           "tags": ["meterological"]},
-            "optradshelt": {"keyword": "OPTRADSHELT:", "describe": "Option for local and remote radiation sheltering" +
-                                                                    "0  Local controls on shortwave radiation\n" + \
-                                                                    "1  Remote controls on diffuse shortwave\n" + \
-                                                                    "2  Remote controls on entire shortwave\n" + \
-                                                                    "3  No sheltering", "value": 0, "tags": ["meterological"]},
+
             "tlinke": {"keyword": "TLINKE:", "describe": "Atmospheric turbidity parameter", "value": 2.5,
-                       "tags": ["meterological"]},
+                       "tags": ["meterological"], "section": 3, "subsection": "Meteorological Variables"},
+            "templapse": {"keyword": "TEMPLAPSE:", "describe": "Temperature lapse rate", "value": -0.0065,
+                          "tags": ["meterological"], "section": 3, "subsection": "Meteorological Variables"},
+            "preclapse": {"keyword": "PRECLAPSE:", "describe": "Precipitation lapse rate", "value": 0,
+                          "tags": ["meterological"], "section": 3, "subsection": "Meteorological Variables"},
+            "hydrometstations": {"keyword": "HYDROMETSTATIONS:",
+                                 "describe": "Hydrometeorological station file (*.sdf)", "value": None,
+                                 "tags": ["meterological"], "section": 3, "subsection": "Meteorological Data"},
+            "hydrometgrid": {"keyword": "HYDROMETGRID:", "describe": "Hydrometeorological grid data file (*.gdf)",
+                             "value": None, "tags": ["meterological"], "section": 3, "subsection": "Meteorological Data"},
+            "gaugestations": {"keyword": "GAUGESTATIONS:", "describe": "Rain Gauge station file (*.sdf)",
+                              "value": None, "tags": ["meterological"], "section": 3, "subsection": "Meteorological Data"},
+
             # ==================================================================================================
             # OUTPUT DATA
             # ==================================================================================================
+
             "outfilename": {"keyword": "OUTFILENAME:", "describe": "Base name of the tMesh and variable",
-                            "value": None, "tags": ["output"]},
+                            "value": None, "tags": ["output"], "section": 3, "subsection": "Output Data"},
             "outhydrofilename": {"keyword": "OUTHYDROFILENAME:", "describe": "Base name for hydrograph output",
-                                 "value": None, "tags": ["output"]},
-            "optspatial": {"keyword": "OPTSPATIAL:", "describe": "Enable dynamic spatial output", "value": 0,
-                           "tags": ["output"]},
-            "optinterhydro": {"keyword": "OPTINTERHYDRO:", "describe": "Enable intermediate hydrograph output",
-                              "value": 0, "tags": ["output"]},
-            "optheader": {"keyword": "OPTHEADER:", "describe": "Enable headers in output files", "value": 1,
-                          "tags": ["output"]},
-            "optviz": {"keyword": "OPTVIZ:", "describe": "Option to write binary output files for visualization\n" + \
-                                                          "0  Do NOT write binary output files for viz\n" + \
-                                                          "1  Write binary output files for viz", "value": 0,
-                       "tags": ["output"]},
-            "outvizfilename": {"keyword": "OUTVIZFILENAME:", "describe": "Filename for viz binary files",
-                               "value": None, "tags": ["output"]},
+                                 "value": None, "tags": ["output"], "section": 3, "subsection": "Output Data"},
             "nodeoutputlist": {"keyword": "NODEOUTPUTLIST:",
                                "describe": "Filename with Nodes for Dynamic Output (*.nol)", "value": None,
-                               "tags": ["output"]},
+                               "tags": ["output"], "section": 3, "subsection": "Output Data"},
             "hydronodelist": {"keyword": "HYDRONODELIST:",
                               "describe": "Filename with Nodes for HydroModel Output (*.nol)", "value": None,
-                              "tags": ["output"]},
+                              "tags": ["output"], "section": 3, "subsection": "Output Data"},
             "outletnodelist": {"keyword": "OUTLETNODELIST:",
                                "describe": "Filename with Interior Nodes for  Output (*.nol)", "value": None,
-                               "tags": ["output"]},
-            "opintrvl": {"keyword": "OPINTRVL:", "describe": "Output interval (hours)", "value": 1, "tags": ["output"]},
-            "spopintrvl": {"keyword": "SPOPINTRVL:", "describe": "Spatial output interval (hours)", "value": 50000,
-                           "tags": ["output"]},
+                               "tags": ["output"], "section": 3, "subsection": "Output Data"},
+
+            # ==================================================================================================
+            # Module Input Files
+            # ==================================================================================================
+
+            "respolygonid": {"keyword": "RESPOLYGONID:", "describe": "Path to file of node IDs representing reservoirs",
+                             "value": None, "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
+            "resdata": {"keyword": "RESDATA:", "describe": "Path to file of elevation-discharge-storage information for each type of reservoir",
+                        "value": None, "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
+            "snowfilename": {"keyword": "SNOWFILENAME:", "describe": "Snow parameter reference file (*.spf)",
+                             "value": None, "tags": ["meterological"], "section": 3, "subsection": "Module Input Files"},
+            "channelconductivity": {"keyword": "CHANNELCONDUCTIVITY:", "describe": "Conductivity in channel for all methods (mm/hr)",
+                                    "value": 0, "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
+            "transientconductivity": {"keyword": "TRANSIENTCONDUCTIVITY:", "describe": "Conductivity in channel during transient period in (mm/hr)",
+                                      "value": 0, "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
+            "transienttime": {"keyword": "TRANSIENTTIME:", "describe": "Time until transient period ends (hours)", "value": 0,
+                              "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
+            "channelporosity": {"keyword": "CHANNELPOROSITY:", "describe": "Porosity in channel", "value": 0,
+                                "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
+            "chanporeindex": {"keyword": "CHANPOREINDEX:", "describe": "Channel pore index in channel", "value": 0,
+                              "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
+            "chanpsib": {"keyword": "CHANPSIB:", "describe": "Matric potential in channel", "value": 0,
+                         "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
+
             # ==================================================================================================
             # FORECAST MODE
             # ==================================================================================================
             "forecastmode": {"keyword": "FORECASTMODE:", "describe": "Rainfall Forecasting Mode Option", "value": 0,
-                             "tags": ["forecast"]},
-            # TODO need to update model mode descriptions
+                             "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
             "forecasttime": {"keyword": "FORECASTTIME:", "describe": "Forecast Time (hours from start)", "value": 0,
-                             "tags": ["forecast"]},
+                             "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
             "forecastleadtime": {"keyword": "FORECASTLEADTIME:", "describe": "Forecast Lead Time (hours) ",
-                                 "value": 0, "tags": ["forecast"]},
+                                 "value": 0, "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
             "forecastlength": {"keyword": "FORECASTLENGTH:", "describe": "Forecast Window Length (hours)", "value": 0,
-                               "tags": ["forecast"]},
+                               "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
             "forecastfile": {"keyword": "FORECASTFILE:", "describe": "Base name of the radar QPF grids",
-                             "value": None, "tags": ["forecast"]},
+                             "value": None, "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
             "climatology": {"keyword": "CLIMATOLOGY:", "describe": "Rainfall climatology (mm/hr)", "value": 0,
-                            "tags": ["forecast"]},
+                            "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
             "raindistribution": {"keyword": "RAINDISTRIBUTION:", "describe": "Distributed or MAP radar rainfall",
-                                 "value": 0, "tags": ["forecast"]},
-            # ==================================================================================================
-            # STOCHASTIC MODE
-            # ==================================================================================================
-            "stochasticmode": {"keyword": "STOCHASTICMODE:", "describe": "Stochastic Climate Mode Option", "value": 0,
-                               "tags": ["stochastic"]},
-            "pmean": {"keyword": "PMEAN:", "describe": "Mean rainfall intensity (mm/hr)	", "value": 0,
-                      "tags": ["stochastic"]},
-            "stdur": {"keyword": "STDUR:", "describe": "Mean storm duration (hours)", "value": 0,
-                      "tags": ["stochastic"]},
-            "istdur": {"keyword": "ISTDUR:", "describe": "Mean time interval between storms (hours)", "value": 0,
-                       "tags": ["stochastic"]},
-            "seed": {"keyword": "SEED:", "describe": "Random seed", "value": 0, "tags": ["stochastic"]},
-            "period": {"keyword": "PERIOD:", "describe": "Period of variation (hours)", "value": 0,
-                       "tags": ["stochastic"]},
-            "maxpmean": {"keyword": "MAXPMEAN:", "describe": "Maximum value of mean rainfall intensity (mm/hr)",
-                         "value": 0, "tags": ["stochastic"]},
-            "maxstdurmn": {"keyword": "MAXSTDURMN:", "describe": "Maximum value of mean storm duration (hours)",
-                           "value": 0, "tags": ["stochastic"]},
-            "maxistdurmn": {"keyword": "MAXISTDURMN:", "describe": "Maximum value of mean interstorm period (hours)",
-                            "value": 0, "tags": ["stochastic"]},
-            "weathertablename": {"keyword": "WEATHERTABLENAME:", "describe": "File with Stochastic Weather Table",
-                                 "value": None, "tags": ["stochastic"]},
+                                 "value": 0, "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
+
             # ==================================================================================================
             # RESTART MODE
             # ==================================================================================================
-            "restartmode": {"keyword": "RESTARTMODE:", "describe": "Restart Mode Option\n" + \
-                                                                    "0 No reading or writing of restart\n" + \
-                                                                    "1 Write files (only for initial runs)\n" + \
-                                                                    "2 Read file only (to start at some specified time)\n" + \
-                                                                    "Read a restart file and continue to write",
-                            "value": 0, "tags": ["restart"]},
+            "restartmode": {"keyword": "RESTARTMODE:", "describe": ("Restart Mode Option\n"
+                                                                    "0  No reading or writing of restart\n"
+                                                                    "1  Write files (only for initial runs)\n"
+                                                                    "2  Read file only (to start at some specified time)\n"
+                                                                    "3  Read a restart file and continue to write"),
+                            "value": 0, "tags": ["restart"], "section": 5},
             "restartintrvl": {"keyword": "RESTARTINTRVL:", "describe": "Time set for restart output (hours)",
-                              "value": None, "tags": ["restart"]},
+                              "value": None, "tags": ["restart"], "section": 5},
             "restartdir": {"keyword": "RESTARTDIR:", "describe": "Path of directory for restart output",
-                           "value": None, "tags": ["restart"]},
+                           "value": None, "tags": ["restart"], "section": 5},
             "restartfile": {"keyword": "RESTARTFILE:", "describe": "Actual file to restart a run", "value": None,
-                            "tags": ["restart"]},
+                            "tags": ["restart"], "section": 5},
+
             # ==================================================================================================
             # PARALLEL MODE
             # ==================================================================================================
-            "parallelmode": {"keyword": "PARALLELMODE:", "describe": "Parallel or Serial Mode Option\n" + \
-                                                                      "0  Run in serial mode\n" + \
-                                                                      "1  Run in parallel mode",
-                             "value": 0, "tags": ["parallel"]},
-            "graphoption": {"keyword": "GRAPHOPTION:", "describe": "Graph File Type Option\n" + \
-                                                                    "0  Default partitioning of the graph\n" + \
-                                                                    "1  Reach-based partitioning\n" + \
-                                                                    "2  Inlet/outlet-based partitioning", "value": 0,
-                            "tags": ["parallel"]},
+            "parallelmode": {"keyword": "PARALLELMODE:", "describe": ("Parallel or Serial Mode Option\n"
+                                                                      "0  Run in serial mode\n"
+                                                                      "1  Run in parallel mode"),
+                             "value": 0, "tags": ["parallel"], "section": 6},
+            "graphoption": {"keyword": "GRAPHOPTION:", "describe": ("Graph File Type Option\n"
+                                                                    "0  Default partitioning of the graph\n"
+                                                                    "1  Reach-based partitioning\n"
+                                                                    "2  Inlet/outlet-based partitioning"),
+                            "value": 0, "tags": ["parallel"], "section": 6},
             "graphfile": {"keyword": "GRAPHFILE:", "describe": "Reach connectivity filename (graph file option 1,2)",
-                          "value": None, "tags": ["parallel"]}
+                          "value": None, "tags": ["parallel"], "section": 6},
         }
 
         return input_file

--- a/pytRIBS/shared/inout.py
+++ b/pytRIBS/shared/inout.py
@@ -71,84 +71,118 @@ class InOut:
                 z, bc = row['elevation'], int(row['bc'])
                 file.write(f"{x} {y} {z} {bc}\n")
 
-    def write_input_file(self, output_file_path, detailed=False):
+    def write_input_file(self, output_file_path):
         """
-        Writes .in file for tRIBS model simulation.
-        :param self:
-        :param output_file_path: Location to write input file to.
-        :param detailed: Option to print input file with option descriptions and related info.
+        Writes .in file for tRIBS model simulation, organized into sections
+        matching the tRIBS input file template format.
+        :param output_file_path: Path to write input file to.
         """
-        if detailed:
-            tags = ['time', 'mesh', 'flow', 'hydro', 'spatial', 'meterological', 'output', 'forecast', 'stochastic',
-                    'restart', 'parallel']
-            headers = {'time': 'Time Variables', 'mesh': 'Mesh Options', 'flow': 'Routing Variables',
-                       'hydro': 'Hydrologic Processes',
-                       'spatial': 'Spatial Data Inputs', 'meterological': 'Meterological Options and Data',
-                       'output': 'Model Output Paths and Options',
-                       'forecast': 'Forecast Mode', 'stochastic': 'Stochastic Mode', 'restart': 'Restart Mode',
-                       'parallel': 'Parallel Mode'}
+        SECTION_TITLES = {
+            1: "Section 1: Model Run Parameters",
+            2: "Section 2: Model Run Options",
+            3: "Section 3: Model Input Files and Pathnames",
+            4: "Section 4: Model Modes",
+            5: "Section 5: Restart Mode Options",
+            6: "Section 6: Parallel Mode Options",
+        }
 
-            meta = "This is a template input file for tRIBS 5.2.0. The file is divided in sections mirroring documentation\n" + \
-                   "found at: https://tribshms.readthedocs.io/en/latest/man/Model%20Input%20File.html#input-file-options\n" + \
-                   "Some values are already provided in the line following the keyword, where keywords are shown in all caps.\n" + \
-                   "Where values are not provided are marked by the string \"Update!\". Following the value is a short description of \n" + \
-                   "what the keyword does, alongside available options. Note: only values required by given a option must be specified.\n\n"
+        HEADER = (
+            "##############################################################################\n"
+            "##\n"
+            "##                    tRIBS Distributed Hydrologic Model\n"
+            "##\n"
+            "##              TIN-based Real-time Integrated Basin Simulator\n"
+            "##                       Ralph M. Parsons Laboratory\n"
+            "##                  Massachusetts Institute of Technology\n"
+            "##\n"
+            "##############################################################################\n"
+        )
 
-            current_datetime = datetime.now()
-            current_user = getpass.getuser()
+        def _options_block(entries):
+            """Build ## comment lines for keywords that have enumerated options."""
+            has_options = [e for e in entries
+                           if len([l for l in (e.get('describe') or '').split('\n') if l.strip()]) > 1]
+            if not has_options:
+                return []
+            col = max(len(f"##  {e['keyword']}") for e in has_options) + 3
+            lines = []
+            for entry in has_options:
+                describe = entry.get('describe') or ''
+                opt_lines = [l for l in describe.split('\n') if l.strip()][1:]
+                prefix = f"##  {entry['keyword']}".ljust(col)
+                indent = "##" + " " * (col - 2)
+                lines.append(f"{prefix}{opt_lines[0]}\n")
+                for opt in opt_lines[1:]:
+                    lines.append(f"{indent}{opt}\n")
+                lines.append("##\n")
+            return lines
 
-            formatted_datetime = current_datetime.strftime("%Y-%m-%d %H:%M:%S")
+        def _section_header(title, option_lines=None):
+            parts = [
+                "\n##=========================================================================\n",
+                "##\n##\n",
+                f"##\t\t\t{title}\n",
+                "##\n##\n",
+            ]
+            if option_lines:
+                parts.extend(option_lines)
+            parts.append("##=========================================================================\n\n")
+            return ''.join(parts)
 
-            with open( output_file_path, 'w') as file:
+        def _write_entry(f, entry):
+            keyword = entry['keyword']
+            describe = entry.get('describe') or ''
+            inline = describe.split('\n')[0] if describe else ''
+            value = entry.get('value')
+            if value is None:
+                value = ''
+            f.write(f"{keyword:<26}{inline}\n")
+            f.write(f"{value}\n\n")
 
-                file.write(f"Created by: {current_user}\n")
-                file.write(f"On: {formatted_datetime}\n\n")
+        # Group entries by section/subsection, preserving insertion order
+        section_data = {}
+        extras = []
+        for entry in self.options.values():
+            sec = entry.get('section')
+            if sec is None:
+                extras.append(entry)
+            else:
+                subsec = entry.get('subsection') or ''
+                if sec not in section_data:
+                    section_data[sec] = {}
+                if subsec not in section_data[sec]:
+                    section_data[sec][subsec] = []
+                section_data[sec][subsec].append(entry)
 
-                string = 'Input File Template for tRIBS Version 5.3.0'
-                underline = '=' * len(string)
-                file.write(f'{underline}\n{string}\n{underline}\n\n')
-                file.write(meta)
+        with open(output_file_path, 'w') as f:
+            f.write(HEADER)
 
-                for tag in tags:
-                    underline = '=' * len(f'Section: {headers[tag]}')
-                    file.write(f'{underline}\nSection: {headers[tag]}\n{underline}\n\n')
-                    result = [item for item in self.options.values() if
-                              any(tag in _tag for _tag in item.get("tags", []))]
+            for sec_num in sorted(section_data):
+                title = SECTION_TITLES.get(sec_num, f"Section {sec_num}")
+                all_entries = [e for sub in section_data[sec_num].values() for e in sub]
+                opt_lines = _options_block(all_entries)
+                f.write(_section_header(title, opt_lines if opt_lines else None))
 
-                    for dictionary in result:
-                        keyword = dictionary['keyword']
-                        file.write(f'{keyword}\n')
-                        val = dictionary['value']
-                        if val is not None:
-                            file.write(f"{dictionary['value']}\n\n")
-                        else:
-                            file.write(f"Update!\n\n")
+                for subsec, entries in section_data[sec_num].items():
+                    if subsec:
+                        f.write(f"## {subsec}\n## {'-' * len(subsec)}\n\n")
+                    for entry in entries:
+                        _write_entry(f, entry)
+                    if subsec:
+                        f.write('\n')
 
-                        description = dictionary['describe']
-                        if description is not None:
-                            file.write(f"Description:\n{description}\n")
-                        else:
-                            file.write(f"None\n")
-                        file.write(f" \n")
-        else:
-            with open(output_file_path, 'w') as output_file:
+            if extras:
+                f.write(_section_header("Additional Options"))
+                for entry in extras:
+                    _write_entry(f, entry)
 
-                current_datetime = datetime.now()
-                current_user = getpass.getuser()
-
-                formatted_datetime = current_datetime.strftime("%Y-%m-%d %H:%M:%S")
-
-                output_file.write(f"Created by: {current_user}\n")
-                output_file.write(f"On: {formatted_datetime}\n\n")
-
-                for key, subdict in self.options.items():
-                    if "keyword" in subdict and "value" in subdict:
-                        keyword = subdict["keyword"]
-                        value = subdict["value"]
-                        if value is None:
-                            value = ""
-                        output_file.write(f"{keyword}\n")
-                        output_file.write(f"{value}\n\n")
+            f.write(
+                "\n##=========================================================================\n"
+                "##\n##\n"
+                "##\t\t\t\tEnd\n"
+                "##\n##\n"
+                "##=========================================================================\n"
+            )
 
 
 


### PR DESCRIPTION
This pull request refactors the tRIBS input file writer in pytRIBS to produce human readable, organized output files, and updates the keyword dictionary to align with the upcoming tRIBS v6.0.0 release.
                                                                                                                                                                                                                                             
Previously, `write_input_file()` produced a flat list of keyword/value pairs with no section organization or inline descriptions, making the generated files difficult to read compared to example templates. The new output matches the standard tRIBS input file template format: organized into numbered sections with subsection headers, inline keyword descriptions, and aligned option tables in comment blocks.                                                           
                  
**Technical Changes**
* `inout.py`: Rewrote `write_input_file()` to generate ##-delimited section headers, subsection headers, inline descriptions on keyword lines, and auto-generated option comment blocks for keywords with description of the choices available.                                                                                                                                                                                                
* `infile_mixin.py`: Added section and subsection fields to all keyword entries to drive the new writer. Keywords not yet assigned to a section are written under an "Additional Options" block at the end of the file.
* `infile_mixin.py`: Added `SNOWFILENAME` keyword (new in tRIBS v6.0.0). Moved channel transmission loss parameters (`CHANNELCONDUCTIVITY`, `TRANSIENTCONDUCTIVITY`, `TRANSIENTTIME`, `CHANNELPOROSITY`, `CHANPOREINDEX`, `CHANPSIB`) and reservoir parameters (`RESPOLYGONID`, `RESDATA`) from Section 2 into a dedicated "Module Input Files" subsection in Section 3.                                                                                                                                  

**Breaking Changes**
* `write_input_file(path, detailed=True)` will raise a `TypeError`, the detailed parameter no longer exists. Call as `write_input_file(path)`.    