### PR TITLE
Refactor Soil & Land use Parameter File Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,24 @@ A full tRIBS model setup, simulation, and analysis is provided [here.](https://z
 PytRIBS uses semantic versioning. Currently, we are in the initial development phase--anything MAY change at any time and
 this package SHOULD NOT be considered stable.
 
-## Version 0.7.2 (04/02/2026)
+## [1.0.0] - Unreleased
+pytRIBS v1.0.0 is the first stable release of the package, moving out of beta and aligning pytRIBS with the tRIBS v6.0.0 model release. Because it targets the reworked v6.0.0 input structure, this release is not backwards compatible with files produced for earlier tRIBS versions. This version standardizes how pytRIBS reads and writes the soil, land use, and gridded parameter files to the new v6.0.0 format, adds support for the new snow parameter file (`.spf`), and updates the data-processing workflows that generate these files. **For examples of the updated v6.0.0 input structure and the new snow parameter files (.spf), see our [example repository](https://github.com/tRIBS-Model/pytRIBS-examples).**
+
+The v1.0.0 changes listed below are abbreviated. For specific details refer to the tRIBS Wiki or the pull request links associated with each change.   
+
+### Added
+* **Snow Parameter File (`.spf`):** Snow physics constants can now be read from and written to a dedicated `.spf` file, and are loaded automatically when referenced in the main input file. ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/34))
+* **Root Zone Depth Parameter:** Added the `RZD_m` parameter to the land use table (`.ldt`). ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/XX))
+
+### Changed & Refactored
+* **Standardized File Formats:** Reworked the soil (`.sdt`), land use (`.ldt`), and grid data (`.gdf`) readers and writers to the new single-header, comma-delimited v6.0.0 format. ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/34))
+* **Soil Textures:** Soil textures are now written to a `*_textures.csv` sidecar file instead of an extra column in the `.sdt`. ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/34))
+* **Static Land Use Grids:** Grid-file path validation now recognizes the new static gridded land use option (`OPTLANDUSE = 2`). ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/34))
+  
+### Removed
+* **Legacy Land Use Parameters:** Removed the Gray (1970) interception parameters (`a`, `b1`) from the land use table. ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/34))
+
+### Version 0.7.2 (04/02/2026)
 This release fixes an issue users on certain versions of Python and introduces GitHub Actions.
 
 #### Added

--- a/pytRIBS/classes.py
+++ b/pytRIBS/classes.py
@@ -119,6 +119,10 @@ class Model(Infile, Shared, Aux, ModelProcessor, Preprocess, InOut):
         if input_file is not None:
             self.read_input_file(input_file)
 
+            # Load snow parameters from the *.spf file if one is referenced
+            if self.options['snowfilename']['value'] is not None:
+                self.read_snow_params()
+
         Meta.__init__(self)
 
         if meta is not None:

--- a/pytRIBS/classes.py
+++ b/pytRIBS/classes.py
@@ -114,6 +114,7 @@ class Model(Infile, Shared, Aux, ModelProcessor, Preprocess, InOut):
     def __init__(self, input_file=None, met=None, land=None, soil=None, mesh=None, meta=None):
         # attributes
         self.options = self.create_input_file()  # input options for tRIBS model run
+        self.snow_options = self.create_snow_params()  # snow module parameter options
 
         if input_file is not None:
             self.read_input_file(input_file)
@@ -136,6 +137,8 @@ class Model(Infile, Shared, Aux, ModelProcessor, Preprocess, InOut):
     def __getattr__(self, name):
         if name in self.options:
             return self.options[name]
+        if name in self.snow_options:
+            return self.snow_options[name]
         raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
 
     def __dir__(self):

--- a/pytRIBS/land/land.py
+++ b/pytRIBS/land/land.py
@@ -132,7 +132,8 @@ class LandProcessor(InOut):
                 'V': None,
                 'LAI': None,
                 'theta*_s': None,
-                'theta*_t': None
+                'theta*_t': None,
+                'RZD_m': 9999.99
             })
 
         return classified_image, class_list
@@ -236,7 +237,8 @@ class LandProcessor(InOut):
                 'V': None,
                 'LAI': None,
                 'theta*_s': None,
-                'theta*_t': None
+                'theta*_t': None,
+                'RZD_m': 9999.99
             })
 
         return classified_data, class_list

--- a/pytRIBS/land/land.py
+++ b/pytRIBS/land/land.py
@@ -121,8 +121,6 @@ class LandProcessor(InOut):
         for cl in classes:
             class_list.append({
                 'ID': cl,
-                'a': None,
-                'b1': None,
                 'P': None,
                 'S': None,
                 'K': None,
@@ -227,8 +225,6 @@ class LandProcessor(InOut):
         for cl in classes:
             class_list.append({
                 'ID': cl,
-                'a': None,
-                'b1': None,
                 'P': None,
                 'S': None,
                 'K': None,

--- a/pytRIBS/model/model.py
+++ b/pytRIBS/model/model.py
@@ -110,7 +110,7 @@ class ModelProcessor:
 
         print("\nChecking if grid files exist.\n")
 
-        if int(instance.options["optlanduse"]["value"]) == 1:
+        if int(instance.options["optlanduse"]["value"]) in (1, 2):
             print("Model is set to read landuse grid files: checking paths and .gdf file")
             instance.read_grid_data_file("land")
 

--- a/pytRIBS/shared/inout.py
+++ b/pytRIBS/shared/inout.py
@@ -184,7 +184,72 @@ class InOut:
                 "##=========================================================================\n"
             )
 
+    def write_snow_params(self, output_file_path='data/model/snow_params.spf'):
+        """
+        Writes a tRIBS snow parameter file (*.spf) with default values and automatically
+        sets the SNOWFILENAME input option to the written file path. This method is only
+        needed when the snow module is enabled (OPTSNOW: 1).
 
+        This method is available on the Model class. After calling it, the SNOWFILENAME
+        keyword in the model input file will be populated automatically when
+        write_input_file() is called.
+
+        Example
+        -------
+        >>> from pytRIBS.classes import Model
+        >>> m = Model()
+        >>> m.write_snow_params('data/model/snow_params.spf')
+
+        The written file follows the tRIBS snow parameter file format (*.spf):
+
+        ## Section Name
+        ## ------------
+        KEYWORD:                  Description
+        value
+
+        All values are set to physically reasonable defaults. Review and adjust
+        parameter values for your specific watershed before running the model.
+        See tRIBS documentation for parameter descriptions.
+
+        :param output_file_path: Path to write the snow parameter file to. Defaults to 'data/model/snow_params.spf',
+            matching the standard project directory structure created by the Project class. If you are not using
+            the default project structure, provide the full path explicitly.
+        """
+        sections = {
+            "General Snow Parameters": [
+                ("IRREDUCIBLE_SAT:",         "Irreducible water saturation (Volumetric fraction of Pore Space)", 0.01),
+                ("K_SAT_REF:",               "Saturated hydraulic conductivity of snowpack (m/s)",               0.0001),
+                ("MIN_SNOW_TEMP:",           "Minimum temperature of snow (Celsius)",                            -27),
+                ("FRESH_SNOW_DENSITY:",      "Fresh snow density baseline (kg/m^3)",                             60),
+                ("CANOPY_WIND_ATTENUATION:", "Coefficient of exponential wind attenuation by canopy (Dimensionless)", 0.4),
+                ("ROUGHNESS_LENGTH:",        "Aerodynamic roughness length (z0) of the snow surface (m)",        0.04),
+            ],
+            "Albedo Parameters": [
+                ("ALBEDO_FRESH:",            "Fresh snow albedo",                                                0.85),
+                ("ALBEDO_DECAY_DRY:",        "Exponential decay rate of albedo for dry snow",                   0.96),
+                ("ALBEDO_DECAY_WET:",        "Exponential decay rate of albedo for wet snow",                   0.82),
+                ("ALBEDO_MIN:",              "Minimum snow albedo which snow cannot decay below",               0.2),
+                ("ALBEDO_RESET_THRESHOLD:",  "Minimum snowfall depth required to reset the age of snow surface (mm)", 0.5),
+            ],
+            "Precipitation Phase Partitioning Parameters": [
+                ("OPTPRECPARTITION:",        "Option for precipitation partitioning scheme\n"
+                                             "0  Wet-bulb temperature threshold\n"
+                                             "1  Linear transition between min/max temperature", 0),
+                ("MAX_WETBULB_TEMP:",        "Upper wet-bulb temperature at which snowfall can occur for OPTPRECPARTITION 0 (Celsius)", 5),
+                ("MIN_TEMP_RAIN:",           "Minimum air temperature at which liquid precipitation can occur for OPTPRECPARTITION 1 (Celsius)", 0),
+                ("MAX_TEMP_SNOW:",           "Maximum air temperature at which snowfall can occur for OPTPRECPARTITION 1 (Celsius)", 4),
+            ],
+        }
+
+        with open(output_file_path, 'w') as f:
+            for section, entries in sections.items():
+                f.write(f"## {section}\n## {'-' * len(section)}\n\n")
+                for keyword, describe, value in entries:
+                    inline = describe.split('\n')[0]
+                    f.write(f"{keyword:<26}{inline}\n")
+                    f.write(f"{value}\n\n")
+
+        self.options['snowfilename']['value'] = output_file_path
 
     def read_precip_sdf(self, file_path=None):
         """

--- a/pytRIBS/shared/inout.py
+++ b/pytRIBS/shared/inout.py
@@ -184,70 +184,72 @@ class InOut:
                 "##=========================================================================\n"
             )
 
+    @staticmethod
+    def create_snow_params():
+        """
+        Creates a dictionary of snow module parameters with default values, mirroring
+        the structure of create_input_file(). Called at Model initialization and stored
+        as self.snow_options. Parameters can be set the same way as main input keywords:
+
+        >>> model.irreducible_sat['value'] = 0.02
+
+        :return: dict of snow parameters keyed by lowercase parameter name.
+        """
+        return {
+            'irreducible_sat':         {'keyword': 'IRREDUCIBLE_SAT:',         'describe': 'Irreducible water saturation (Volumetric fraction of Pore Space)',                                  'value': 0.01,   'section': 'General Snow Parameters'},
+            'k_sat_ref':               {'keyword': 'K_SAT_REF:',               'describe': 'Saturated hydraulic conductivity of snowpack (m/s)',                                                'value': 0.0001, 'section': 'General Snow Parameters'},
+            'min_snow_temp':           {'keyword': 'MIN_SNOW_TEMP:',           'describe': 'Minimum temperature of snow (Celsius)',                                                              'value': -27,    'section': 'General Snow Parameters'},
+            'fresh_snow_density':      {'keyword': 'FRESH_SNOW_DENSITY:',      'describe': 'Fresh snow density baseline (kg/m^3)',                                                               'value': 60,     'section': 'General Snow Parameters'},
+            'canopy_wind_attenuation': {'keyword': 'CANOPY_WIND_ATTENUATION:', 'describe': 'Coefficient of exponential wind attenuation by canopy (Dimensionless)',                             'value': 0.4,    'section': 'General Snow Parameters'},
+            'roughness_length':        {'keyword': 'ROUGHNESS_LENGTH:',        'describe': 'Aerodynamic roughness length (z0) of the snow surface (m)',                                         'value': 0.04,   'section': 'General Snow Parameters'},
+            'albedo_fresh':            {'keyword': 'ALBEDO_FRESH:',            'describe': 'Fresh snow albedo',                                                                                  'value': 0.85,   'section': 'Albedo Parameters'},
+            'albedo_decay_dry':        {'keyword': 'ALBEDO_DECAY_DRY:',        'describe': 'Exponential decay rate of albedo for dry snow',                                                     'value': 0.96,   'section': 'Albedo Parameters'},
+            'albedo_decay_wet':        {'keyword': 'ALBEDO_DECAY_WET:',        'describe': 'Exponential decay rate of albedo for wet snow',                                                     'value': 0.82,   'section': 'Albedo Parameters'},
+            'albedo_min':              {'keyword': 'ALBEDO_MIN:',              'describe': 'Minimum snow albedo which snow cannot decay below',                                                  'value': 0.2,    'section': 'Albedo Parameters'},
+            'albedo_reset_threshold':  {'keyword': 'ALBEDO_RESET_THRESHOLD:',  'describe': 'Minimum snowfall depth required to reset the age of snow surface (mm)',                             'value': 0.5,    'section': 'Albedo Parameters'},
+            'optprecpartition':        {'keyword': 'OPTPRECPARTITION:',        'describe': 'Option for precipitation partitioning scheme\n0  Wet-bulb temperature threshold\n1  Linear transition between min/max temperature', 'value': 0, 'section': 'Precipitation Phase Partitioning Parameters'},
+            'max_wetbulb_temp':        {'keyword': 'MAX_WETBULB_TEMP:',        'describe': 'Upper wet-bulb temperature at which snowfall can occur for OPTPRECPARTITION 0 (Celsius)',           'value': 5,      'section': 'Precipitation Phase Partitioning Parameters'},
+            'min_temp_rain':           {'keyword': 'MIN_TEMP_RAIN:',           'describe': 'Minimum air temperature at which liquid precipitation can occur for OPTPRECPARTITION 1 (Celsius)',  'value': 0,      'section': 'Precipitation Phase Partitioning Parameters'},
+            'max_temp_snow':           {'keyword': 'MAX_TEMP_SNOW:',           'describe': 'Maximum air temperature at which snowfall can occur for OPTPRECPARTITION 1 (Celsius)',              'value': 4,      'section': 'Precipitation Phase Partitioning Parameters'},
+        }
+
     def write_snow_params(self, output_file_path='data/model/snow_params.spf'):
         """
-        Writes a tRIBS snow parameter file (*.spf) with default values and automatically
+        Writes a tRIBS snow parameter file (*.spf) from self.snow_options and automatically
         sets the SNOWFILENAME input option to the written file path. This method is only
         needed when the snow module is enabled (OPTSNOW: 1).
 
-        This method is available on the Model class. After calling it, the SNOWFILENAME
-        keyword in the model input file will be populated automatically when
-        write_input_file() is called.
+        Parameter values are set the same way as main input file keywords, via self.snow_options:
 
         Example
         -------
         >>> from pytRIBS.classes import Model
         >>> m = Model()
+
+        >>> # Adjust parameters before writing
+        >>> m.irreducible_sat['value'] = 0.02
+        >>> m.albedo_fresh['value'] = 0.90
         >>> m.write_snow_params('data/model/snow_params.spf')
 
-        The written file follows the tRIBS snow parameter file format (*.spf):
-
-        ## Section Name
-        ## ------------
-        KEYWORD:                  Description
-        value
-
-        All values are set to physically reasonable defaults. Review and adjust
-        parameter values for your specific watershed before running the model.
-        See tRIBS documentation for parameter descriptions.
-
-        :param output_file_path: Path to write the snow parameter file to. Defaults to 'data/model/snow_params.spf',
-            matching the standard project directory structure created by the Project class. If you are not using
-            the default project structure, provide the full path explicitly.
+        :param output_file_path: Path to write the snow parameter file to. Defaults to
+            'data/model/snow_params.spf', matching the standard project directory structure
+            created by the Project class. If you are not using the default project structure,
+            provide the full path explicitly.
         """
-        sections = {
-            "General Snow Parameters": [
-                ("IRREDUCIBLE_SAT:",         "Irreducible water saturation (Volumetric fraction of Pore Space)", 0.01),
-                ("K_SAT_REF:",               "Saturated hydraulic conductivity of snowpack (m/s)",               0.0001),
-                ("MIN_SNOW_TEMP:",           "Minimum temperature of snow (Celsius)",                            -27),
-                ("FRESH_SNOW_DENSITY:",      "Fresh snow density baseline (kg/m^3)",                             60),
-                ("CANOPY_WIND_ATTENUATION:", "Coefficient of exponential wind attenuation by canopy (Dimensionless)", 0.4),
-                ("ROUGHNESS_LENGTH:",        "Aerodynamic roughness length (z0) of the snow surface (m)",        0.04),
-            ],
-            "Albedo Parameters": [
-                ("ALBEDO_FRESH:",            "Fresh snow albedo",                                                0.85),
-                ("ALBEDO_DECAY_DRY:",        "Exponential decay rate of albedo for dry snow",                   0.96),
-                ("ALBEDO_DECAY_WET:",        "Exponential decay rate of albedo for wet snow",                   0.82),
-                ("ALBEDO_MIN:",              "Minimum snow albedo which snow cannot decay below",               0.2),
-                ("ALBEDO_RESET_THRESHOLD:",  "Minimum snowfall depth required to reset the age of snow surface (mm)", 0.5),
-            ],
-            "Precipitation Phase Partitioning Parameters": [
-                ("OPTPRECPARTITION:",        "Option for precipitation partitioning scheme\n"
-                                             "0  Wet-bulb temperature threshold\n"
-                                             "1  Linear transition between min/max temperature", 0),
-                ("MAX_WETBULB_TEMP:",        "Upper wet-bulb temperature at which snowfall can occur for OPTPRECPARTITION 0 (Celsius)", 5),
-                ("MIN_TEMP_RAIN:",           "Minimum air temperature at which liquid precipitation can occur for OPTPRECPARTITION 1 (Celsius)", 0),
-                ("MAX_TEMP_SNOW:",           "Maximum air temperature at which snowfall can occur for OPTPRECPARTITION 1 (Celsius)", 4),
-            ],
-        }
+        section_data = {}
+        for entry in self.snow_options.values():
+            sec = entry['section']
+            if sec not in section_data:
+                section_data[sec] = []
+            section_data[sec].append(entry)
 
         with open(output_file_path, 'w') as f:
-            for section, entries in sections.items():
+            for section, entries in section_data.items():
                 f.write(f"## {section}\n## {'-' * len(section)}\n\n")
-                for keyword, describe, value in entries:
-                    inline = describe.split('\n')[0]
-                    f.write(f"{keyword:<26}{inline}\n")
-                    f.write(f"{value}\n\n")
+                for entry in entries:
+                    inline = entry['describe'].split('\n')[0]
+                    f.write(f"{entry['keyword']:<26}{inline}\n")
+                    f.write(f"{entry['value']}\n\n")
 
         self.options['snowfilename']['value'] = output_file_path
 

--- a/pytRIBS/shared/inout.py
+++ b/pytRIBS/shared/inout.py
@@ -504,9 +504,14 @@ class InOut:
         """
         Returns list of dictionaries for each type of landuse specified in the .ldt file.
 
-        Land Use Reclassification Table Structure (*.ldt, see tRIBS documentation for more details)
-        #Types	#Params
-        ID	 P	S	K	b2	Al	 h	Kt	Rs	V LAI theta*_s theta*_t
+        Land Use Reclassification Table Structure (*.ldt). The first line is a
+        descriptive, comma-delimited header that tRIBS skips; each following line is a
+        comma-delimited row of parameter values:
+
+        ID,P_[],S_mm,K_mm/hr,b2_1/mm,Al_[],h_m,Kt_[],Rs_s/m,V_[],LAI_[],Theta*s_[],Theta*t_[],RZD_m
+
+        RZD_m (root zone depth, m) must be present for every type; a value of 9999.99 tells
+        tRIBS to fall back to its internal default.
 
         """
         if file_path is None:
@@ -521,19 +526,17 @@ class InOut:
         with open(file_path, 'r') as file:
             lines = file.readlines()
 
-        metadata = lines.pop(0)
-        num_types, num_params = map(int, metadata.strip().split())
-        param_standard = 13
-
-        if num_params != param_standard:
-            print(f"The number parameters in {file_path} do not conform with standard landuse .ldt format.")
-            return
+        lines.pop(0)  # discard the descriptive header line (skipped by tRIBS)
+        param_standard = 14
 
         for l in lines:
-            land_info = l.strip().split()
+            if not l.strip():
+                continue
+
+            land_info = [v.strip() for v in l.strip().split(',')]
 
             if len(land_info) == param_standard:
-                _id, p, s, k, b_2, al, h, kt, rs, v, lai, tstar_s, tstar_t = land_info
+                _id, p, s, k, b_2, al, h, kt, rs, v, lai, tstar_s, tstar_t, rzd = land_info
                 station = {
                     "ID": _id,
                     "P": p,
@@ -547,40 +550,45 @@ class InOut:
                     "V": v,
                     "LAI": lai,
                     "theta*_s": tstar_s,
-                    "theta*_t": tstar_t
+                    "theta*_t": tstar_t,
+                    "RZD_m": rzd
                 }
                 landuse_list.append(station)
-
-        if len(landuse_list) != num_types:
-            print("Error: Number of land types does not match the specified count.")
+            else:
+                print(f"Skipping row in {file_path}: expected {param_standard} comma-separated "
+                      f"values, got {len(land_info)}.")
 
         return landuse_list
     @staticmethod
     def write_landuse_table(landuse_list, file_path):
         """
-        Writes out Land Use Reclassification Table(*.ldt) file with the following format:
-        #Types	#Params
-        ID	 P	S	K	b2	Al	 h	Kt	Rs	V LAI theta*_s theta*_t
+        Writes out a Land Use Reclassification Table (*.ldt) in the tRIBS format: a
+        single descriptive header line (skipped by tRIBS) followed by comma-delimited rows
+        of parameter values:
 
-        Note: the Gray (1970) interception parameters (a, b1) present in pre-v6.0.0
-        land use tables have been removed. Tables written by this function are not
-        compatible with tRIBS versions prior to v6.0.0.
+        ID,P_[],S_mm,K_mm/hr,b2_1/mm,Al_[],h_m,Kt_[],Rs_s/m,V_[],LAI_[],Theta*s_[],Theta*t_[],RZD_m
+
+        Notes:
+        - The Gray (1970) interception parameters (a, b1) present in pre-v6.0.0 land use
+          tables have been removed. Tables written by this function are not compatible with
+          tRIBS versions prior to v6.0.0.
+        - RZD_m (root zone depth, m) must be present for every type. If a dictionary omits it,
+          9999.99 is written, which tells tRIBS to use its internal default.
 
         :param landuse_list: List of dictionaries containing land information specified by .ldt structure above.
         :param file_path: Path to save *.ldt file.
         """
-        param_standard = 13
+        header = ("ID,P_[],S_mm,K_mm/hr,b2_1/mm,Al_[],h_m,Kt_[],Rs_s/m,V_[],LAI_[],"
+                  "Theta*s_[],Theta*t_[],RZD_m")
 
         with open(file_path, 'w') as file:
-            metadata = f"{len(landuse_list)} {param_standard}\n"
-            file.write(metadata)
+            file.write(header + "\n")
 
             for type in landuse_list:
-                line = (f"{str(type['ID'])} {str(type['P'])} {str(type['S'])} {str(type['K'])} "
-                        f"{str(type['b2'])} {str(type['Al'])} {str(type['h'])} {str(type['Kt'])} "
-                        f"{str(type['Rs'])} {str(type['V'])} {str(type['LAI'])} "
-                        f"{str(type['theta*_s'])} {str(type['theta*_t'])}\n")
-                file.write(line)
+                row = [type['ID'], type['P'], type['S'], type['K'], type['b2'], type['Al'],
+                       type['h'], type['Kt'], type['Rs'], type['V'], type['LAI'],
+                       type['theta*_s'], type['theta*_t'], type.get('RZD_m', 9999.99)]
+                file.write(",".join(str(v) for v in row) + "\n")
 
     def read_grid_data_file(self, grid_type):
         """

--- a/pytRIBS/shared/inout.py
+++ b/pytRIBS/shared/inout.py
@@ -475,7 +475,7 @@ class InOut:
 
         Land Use Reclassification Table Structure (*.ldt, see tRIBS documentation for more details)
         #Types	#Params
-        ID	a	b1	 P	S	K	b2	Al	 h	Kt	Rs	V LAI theta*_s theta*_t
+        ID	 P	S	K	b2	Al	 h	Kt	Rs	V LAI theta*_s theta*_t
 
         """
         if file_path is None:
@@ -492,21 +492,19 @@ class InOut:
 
         metadata = lines.pop(0)
         num_types, num_params = map(int, metadata.strip().split())
-        param_standard = 15
+        param_standard = 13
 
         if num_params != param_standard:
-            print(f"The number parameters in {file_path} do not conform with standard landuse .sdt format.")
+            print(f"The number parameters in {file_path} do not conform with standard landuse .ldt format.")
             return
 
         for l in lines:
             land_info = l.strip().split()
 
             if len(land_info) == param_standard:
-                _id, a, b_1, p, s, k, b_2, al, h, kt, rs, v, lai, tstar_s, tstar_t = land_info
+                _id, p, s, k, b_2, al, h, kt, rs, v, lai, tstar_s, tstar_t = land_info
                 station = {
                     "ID": _id,
-                    "a": a,
-                    "b1": b_1,
                     "P": p,
                     "S": s,
                     "K": k,
@@ -527,27 +525,30 @@ class InOut:
 
         return landuse_list
     @staticmethod
-    def write_landuse_table(landuse_list,file_path):
+    def write_landuse_table(landuse_list, file_path):
         """
         Writes out Land Use Reclassification Table(*.ldt) file with the following format:
         #Types	#Params
-        ID	a	b1	 P	S	K	b2	Al	 h	Kt	Rs	V LAI theta*_s theta*_t
+        ID	 P	S	K	b2	Al	 h	Kt	Rs	V LAI theta*_s theta*_t
+
+        Note: the Gray (1970) interception parameters (a, b1) present in pre-v6.0.0
+        land use tables have been removed. Tables written by this function are not
+        compatible with tRIBS versions prior to v6.0.0.
 
         :param landuse_list: List of dictionaries containing land information specified by .ldt structure above.
-        :param file_path: Path to save *.sdt file.
+        :param file_path: Path to save *.ldt file.
         """
-        param_standard = 15
+        param_standard = 13
 
         with open(file_path, 'w') as file:
-            # Write metadata line
             metadata = f"{len(landuse_list)} {param_standard}\n"
             file.write(metadata)
 
-            # Write station information
             for type in landuse_list:
-                line = f"{str(type['ID'])} {str(type['a'])} {str(type['b1'])} {str(type['P'])} {str(type['S'])} {str(type['K'])} " \
-                       f" {str(type['b2'])} {str(type['Al'])} {str(type['h'])} {str(type['Kt'])} {str(type['Rs'])} {str(type['V'])}" \
-                       f" {str(type['LAI'])} {str(type['theta*_s'])} {str(type['theta*_t'])}\n"
+                line = (f"{str(type['ID'])} {str(type['P'])} {str(type['S'])} {str(type['K'])} "
+                        f"{str(type['b2'])} {str(type['Al'])} {str(type['h'])} {str(type['Kt'])} "
+                        f"{str(type['Rs'])} {str(type['V'])} {str(type['LAI'])} "
+                        f"{str(type['theta*_s'])} {str(type['theta*_t'])}\n")
                 file.write(line)
 
     def read_grid_data_file(self, grid_type):

--- a/pytRIBS/shared/inout.py
+++ b/pytRIBS/shared/inout.py
@@ -592,9 +592,17 @@ class InOut:
 
     def read_grid_data_file(self, grid_type):
         """
-        Returns dictionary with content of a specified Grid Data File (.gdf)
-        :param grid_type: string set to "weather", "soil", of "land", with each corresponding to HYDROMETGRID, SCGRID, LUGRID
-        :return: dictionary containg keys and content: "Number of Parameters","Latitude", "Longitude","GMT Time Zone", "Parameters" (a  list of dicts)
+        Returns dictionary with content of a specified Grid Data File (.gdf).
+
+        The .gdf has a single descriptive header line that tRIBS skips,
+        followed by comma-delimited rows of Variable,BasePath,FileExtension:
+
+        Variable,BasePath,FileExtension
+        KS,data/model/soil/KS,asc
+        TS,data/model/soil/TS,asc
+
+        :param grid_type: string set to "weather", "soil", or "land", with each corresponding to HYDROMETGRID, SCGRID, LUGRID
+        :return: dictionary with keys "Number of Parameters" and "Parameters" (a list of dicts)
         """
 
         if grid_type == "weather":
@@ -607,85 +615,49 @@ class InOut:
         parameters = []
 
         with open(option, 'r') as file:
-            num_parameters = int(file.readline().strip())
-            location_info = file.readline().strip().split()
-            latitude, longitude, gmt_timezone = location_info
+            lines = file.readlines()
 
-            variable_count = 0
+        lines.pop(0)  # discard the descriptive header line (skipped by tRIBS)
 
-            for line in file:
-                parts = line.strip().split()
-                if len(parts) == 3:
-                    variable_name, raster_path, raster_extension = parts
-                    variable_count += 1
+        for line in lines:
+            if not line.strip():
+                continue
 
-                    # path_components = raster_path.split(os.path.sep)
-                    #
-                    # # Exclude the last directory as its actually base name
-                    # raster_path = os.path.sep.join(path_components[:-1])
-
-                    # if raster_path != "NO_DATA":
-                    #     if not os.path.exists(raster_path+'/'+raster_extension):
-                    #         print(
-                    #             f"Warning: Raster file not found for Variable '{variable_name}': {raster_path}")
-                    #         raster_path = None
-                    #     elif os.path.getsize(raster_path) == 0:
-                    #         print(
-                    #             f"Warning: Raster file is empty for Variable '{variable_name}': {raster_path}")
-                    #         raster_path = None
-                    # elif raster_path == "NO_DATA":
-                    #     print(
-                    #         f"Warning: No rasters set for variable '{variable_name}'")
-                    #     raster_path = None
-
-                    parameters.append({
-                        'Variable Name': variable_name,
-                        'Raster Path': raster_path,
-                        'Raster Extension': raster_extension
-                    })
-                else:
-                    print(f"Skipping invalid line: {line}")
-
-            if variable_count > num_parameters:
-                print(
-                    "Warning: The number of variables exceeds the number of parameters. This variable has been reset "
-                    "in dictionary.")
+            parts = [v.strip() for v in line.strip().split(',')]
+            if len(parts) == 3:
+                variable_name, raster_path, raster_extension = parts
+                parameters.append({
+                    'Variable Name': variable_name,
+                    'Raster Path': raster_path,
+                    'Raster Extension': raster_extension
+                })
+            else:
+                print(f"Skipping invalid line: {line}")
 
         return {
-            'Number of Parameters': variable_count,
-            'Latitude': latitude,
-            'Longitude': longitude,
-            'GMT Time Zone': gmt_timezone,
+            'Number of Parameters': len(parameters),
             'Parameters': parameters
         }
 
     @staticmethod
     def write_grid_data_file(grid_file, data):
         """
-        Writes the content of a dictionary to a specified Grid Data File (.gdf)
+        Writes the content of a dictionary to a specified Grid Data File (.gdf) in the tRIBS
+        format: a single descriptive header line (skipped by tRIBS) followed by
+        comma-delimited rows of Variable,BasePath,FileExtension.
+
         :param grid_file: path to write out grid file to.
-        :param data: dictionary containing keys and content: "Number of Parameters", "Latitude", "Longitude", "GMT Time Zone", "Parameters" (a list of dicts)
+        :param data: dictionary containing key "Parameters" (a list of dicts with keys
+            'Variable Name', 'Raster Path', 'Raster Extension')
         :return: None
         """
 
         with open(grid_file, 'w') as file:
-            # Write number of parameters
-            file.write(f"{data['Number of Parameters']}\n")
+            file.write("Variable,BasePath,FileExtension\n")
 
-            # Write location info (Latitude, Longitude, GMT Time Zone)
-            file.write(f"{data['Latitude']} {data['Longitude']} {data['GMT Time Zone']}\n")
-
-            # Write parameters
             for param in data['Parameters']:
-                variable_name = param['Variable Name']
-                raster_path = param['Raster Path']
-                raster_extension = param['Raster Extension']
-
-                # # Check if the raster path exists, and if it doesn't, set it to "NO_DATA"
-                # if not os.path.exists(os.path.join(raster_path, raster_extension)):
-                #     raster_path = "NO_DATA"
-
-                file.write(f"{variable_name} {raster_path} {raster_extension}\n")
+                file.write(f"{param['Variable Name']},{param['Raster Path']},"
+                           f"{param['Raster Extension']}\n")
 
     @staticmethod
     def read_ascii(file_path):

--- a/pytRIBS/shared/inout.py
+++ b/pytRIBS/shared/inout.py
@@ -253,6 +253,35 @@ class InOut:
 
         self.options['snowfilename']['value'] = output_file_path
 
+    def read_snow_params(self, file_path=None):
+        """
+        Reads a tRIBS snow parameter file (*.spf) and assigns values to self.snow_options.
+        The *.spf file shares the same keyword/value format as the main input file, so the
+        parsing mirrors read_input_file().
+
+        :param file_path: Path to the *.spf file. Defaults to options['snowfilename']['value'],
+            which is set when the main input file is read or when write_snow_params() is called.
+        """
+        if file_path is None:
+            file_path = self.options['snowfilename']['value']
+
+            if file_path is None:
+                print(self.options['snowfilename']['keyword'] + " is not specified.")
+                return None
+
+        with open(file_path, 'r') as file:
+            lines = file.readlines()
+
+        i = 0
+        while i < len(lines):
+            line = lines[i].strip()
+            line_lower = line.lower()
+            for key, entry in self.snow_options.items():
+                keyword_lower = entry['keyword'].lower()
+                if line_lower.startswith(keyword_lower) and i + 1 < len(lines):
+                    self.snow_options[key]['value'] = lines[i + 1].strip()
+            i += 1
+
     def read_precip_sdf(self, file_path=None):
         """
         Returns list of precip stations, where information from each station is stored in a dictionary.

--- a/pytRIBS/soil/soil.py
+++ b/pytRIBS/soil/soil.py
@@ -1406,20 +1406,17 @@ class SoilProcessor:
         tribsvars.append(ks_decay_param)
         tribsvars.append('theta_s')
         ref_depth = '0-5cm'
-
-        num_param = len(scgrid_vars)
-        lat, lon, gmt = self._polygon_centroid_to_geographic(watershed)
         ext = 'asc'
 
+        # Location and GMT now live in the main input file, not the .gdf (wired separately).
         with open('scgrid.gdf', 'w') as file:
-            file.write(str(num_param) + '\n')
-            file.write(f"{str(lat)}    {str(lon)}     {str(gmt)}\n")
+            file.write("Variable,BasePath,FileExtension\n")
 
             for scgrid, prefix in zip(scgrid_vars, tribsvars):
                 if scgrid == 'FD':
-                    file.write(f"{scgrid}    {relative_path}{prefix}    {ext}\n")
+                    file.write(f"{scgrid},{relative_path}{prefix},{ext}\n")
                 else:
-                    file.write(f"{scgrid}    {relative_path}{prefix}_{ref_depth}    {ext}\n")
+                    file.write(f"{scgrid},{relative_path}{prefix}_{ref_depth},{ext}\n")
 
         os.chdir(init_dir)
 

--- a/pytRIBS/soil/soil.py
+++ b/pytRIBS/soil/soil.py
@@ -179,94 +179,113 @@ class SoilProcessor:
         with open(file_path, 'r') as file:
             lines = file.readlines()
 
-        metadata = lines.pop(0)
-        num_types, num_params = map(int, metadata.strip().split())
+        lines.pop(0)  # discard the descriptive header line (skipped by tRIBS)
         param_standard = 12
 
-        if textures:
-            param_standard += 1
-
-        if num_params != param_standard:
-            print(f"The number parameters in {file_path} do not conform with standard soil .sdt format.")
-            return
-
         for l in lines:
-            soil_info = l.strip().split()
+            if not l.strip():
+                continue
+
+            soil_info = [v.strip() for v in l.strip().split(',')]
 
             if len(soil_info) == param_standard:
-                if textures:
-                    _id, ks, theta_s, theta_r, m, psi_b, f, a_s, a_u, n, _ks, c_s, textures = soil_info
-                    station = {
-                        "ID": _id,
-                        "Ks": ks,
-                        "thetaS": theta_s,
-                        "thetaR": theta_r,
-                        "m": m,
-                        "PsiB": psi_b,
-                        "f": f,
-                        "As": a_s,
-                        "Au": a_u,
-                        "n": n,
-                        "ks": _ks,
-                        "Cs": c_s,
-                        "Texture": textures
-                    }
-                else:
-                    _id, ks, theta_s, theta_r, m, psi_b, f, a_s, a_u, n, _ks, c_s = soil_info
-                    station = {
-                        "ID": _id,
-                        "Ks": ks,
-                        "thetaS": theta_s,
-                        "thetaR": theta_r,
-                        "m": m,
-                        "PsiB": psi_b,
-                        "f": f,
-                        "As": a_s,
-                        "Au": a_u,
-                        "n": n,
-                        "ks": _ks,
-                        "Cs": c_s
-                    }
-
+                _id, ks, theta_s, theta_r, m, psi_b, f, a_s, a_u, n, _ks, c_s = soil_info
+                station = {
+                    "ID": _id,
+                    "Ks": ks,
+                    "thetaS": theta_s,
+                    "thetaR": theta_r,
+                    "m": m,
+                    "PsiB": psi_b,
+                    "f": f,
+                    "As": a_s,
+                    "Au": a_u,
+                    "n": n,
+                    "ks": _ks,
+                    "Cs": c_s
+                }
                 soil_list.append(station)
+            else:
+                print(f"Skipping row in {file_path}: expected {param_standard} comma-separated "
+                      f"values, got {len(soil_info)}.")
 
-        if len(soil_list) != num_types:
-            print("Error: Number of soil types does not match the specified count.")
+        if textures:
+            texture_file = f"{os.path.splitext(file_path)[0]}_textures.csv"
+            if os.path.exists(texture_file):
+                texture_map = self.read_soil_textures(texture_file)
+                for station in soil_list:
+                    station["Texture"] = texture_map.get(station["ID"])
+            else:
+                print(f"Texture reference file {texture_file} not found; 'Texture' not loaded. "
+                      f"Soil textures are written to a sidecar file alongside the .sdt, not into "
+                      f"the table itself.")
+
         return soil_list
+
+    @staticmethod
+    def read_soil_textures(texture_file):
+        """
+        Reads a soil texture reference sidecar (ID,Texture CSV) and returns a dict mapping
+        soil ID -> texture name. This file is for user reference only and is not read by tRIBS;
+        it is written alongside the .sdt by write_soil_table(..., textures=True).
+
+        :param texture_file: Path to the *_textures.csv sidecar file.
+        :return: dict mapping str ID to texture name.
+        """
+        texture_map = {}
+
+        with open(texture_file, 'r') as file:
+            lines = file.readlines()
+
+        lines.pop(0)  # discard the ID,Texture header
+        for l in lines:
+            if not l.strip():
+                continue
+            parts = [v.strip() for v in l.strip().split(',', 1)]
+            if len(parts) == 2:
+                texture_map[parts[0]] = parts[1]
+
+        return texture_map
 
     @staticmethod
     def write_soil_table(soil_list, file_path, textures=False):
         """
-        Writes out Soil Reclassification Table(*.sdt) file with the following format:
-        #Types #Params
-        ID Ks thetaS thetaR m PsiB f As Au n ks Cs
+        Writes out a Soil Reclassification Table (*.sdt) in the tRIBS format: a single
+        descriptive header line (skipped by tRIBS) followed by comma-delimited rows of
+        parameter values:
+
+        ID,Ks_mm/hr,ThetaS_m3/m3,ThetaR_m3/m3,m_[],PsiB_cm,f_1/mm,As_[],Au_[],n_m3/m3,ks_J/msK,Cs_J/m3K
+
+        Soil texture is never written into the .sdt itself: tRIBS reads every value on a row, so
+        a trailing texture column would be parsed as an extra parameter. When textures=True the
+        texture names are instead written to a sidecar reference file, <file_path stem>_textures.csv,
+        with columns ID,Texture. That file is for the user's reference only and is not read by tRIBS.
 
         :param soil_list: List of dictionaries containing soil information specified by .sdt structure above.
         :param file_path: Path to save *.sdt file.
-        :param textures: Optional True/False for writing texture classes to the .sdt file.
+        :param textures: Optional True/False for writing a texture reference sidecar alongside the .sdt.
 
         """
-        param_standard = 12
-
-        if textures:
-            param_standard += 1
+        header = ("ID,Ks_mm/hr,ThetaS_m3/m3,ThetaR_m3/m3,m_[],PsiB_cm,f_1/mm,As_[],Au_[],"
+                  "n_m3/m3,ks_J/msK,Cs_J/m3K")
 
         with open(file_path, 'w') as file:
-            # Write metadata line
-            metadata = f"{len(soil_list)} {param_standard}\n"
-            file.write(metadata)
+            file.write(header + "\n")
 
-            # Write station information
             for type in soil_list:
+                row = [type['ID'], type['Ks'], type['thetaS'], type['thetaR'], type['m'],
+                       type['PsiB'], type['f'], type['As'], type['Au'], type['n'],
+                       type['ks'], type['Cs']]
+                file.write(",".join(str(v) for v in row) + "\n")
 
-                if textures:
-                    line = f"{str(type['ID'])}   {str(type['Ks'])}    {str(type['thetaS'])}    {str(type['thetaR'])}    {str(type['m'])}    {str(type['PsiB'])}    " \
-                           f"{str(type['f'])}    {str(type['As'])}    {str(type['Au'])}    {str(type['n'])}    {str(type['ks'])}    {str(type['Cs'])} {str(type['Texture'])}\n"
-                else:
-                    line = f"{str(type['ID'])}   {str(type['Ks'])}    {str(type['thetaS'])}    {str(type['thetaR'])}    {str(type['m'])}    {str(type['PsiB'])}    " \
-                           f"{str(type['f'])}    {str(type['As'])}    {str(type['Au'])}    {str(type['n'])}    {str(type['ks'])}    {str(type['Cs'])}\n"
-
-                file.write(line)
+        if textures:
+            texture_file = f"{os.path.splitext(file_path)[0]}_textures.csv"
+            with open(texture_file, 'w') as file:
+                file.write("ID,Texture\n")
+                for type in soil_list:
+                    file.write(f"{type['ID']},{type['Texture']}\n")
+            print(f"Soil texture reference written to {texture_file}. This file is for user "
+                  f"reference only and is not read by tRIBS.")
 
     def get_soil_grids(self, bbox, depths, soil_vars, stats, replace=False):
         def retrieve_soil_data(self, bbox, depths, soil_vars, stats):


### PR DESCRIPTION
This pull request adds support for the new tRIBS v6.0.0 snow parameter file (`*.spf`) and migrates the soil reclassification table (`*.sdt`), land use reclassification table (`*.ldt`), and grid data files (`*.gdf`) to the new tRIBS v6.0.0 file format.   

Previously, the reclassification tables and grid data files began with a leading metadata line, a type/parameter count, and for grid files an additional latitude/longitude/GMT line followed by whitespace-delimited data rows. tRIBS v6.0.0 standardizes all of these on a single header line, followed by comma-delimited data rows. This PR updates the readers and writers to match.
  
**Technical Changes**
* `inout.py`: Added `create_snow_params()`, `write_snow_params()`, and `read_snow_params()` for the new tRIBS v6.0.0 snow parameter file (`*.spf`). The `*.spf` shares the main input file's keyword/value format, and `write_snow_params()` sets the `SNOWFILENAME` option automatically.
* `inout.py`: Rewrote `read_landuse_table()`/`write_landuse_table()` to the new single-header, comma-delimited format. The land use table drops the Gray (1970) interception parameters (`a`, `b1`) and adds the new root zone depth parameter (`RZD_m`) as the final column, defaulting to `9999.99` (signals tRIBS to use internal defaultvalue) when omitted.
* `inout.py`: Rewrote `read_grid_data_file()`/`write_grid_data_file()` to the new `Variable,BasePath,FileExtension` header format, dropping the parameter-count line and the latitude/longitude/GMT line for all three grid types (soil, land, weather).
* `classes.py`: `Model` now initializes `snow_options` and exposes snow parameters as attributes; when an input file specifies `SNOWFILENAME`, the referenced `*.spf` is read automatically at construction.
* `soil/soil.py`: Rewrote `read_soil_table()`/`write_soil_table()` to the new format. Soil textures are no longer written as a column in the `*.sdt`. `write_soil_table(..., textures=True)` instead writes a `<name>_textures.csv` reference sidecar, and `read_soil_table(..., textures=True)` merges it back. Updated `run_soil_workflow()` to write `scgrid.gdf` in the new format.
* `land/land.py`: Removed the Gray (1970) interception parameters (`a`, `b1`) from the land use class templates and added the `RZD_m` field.

**Breaking Changes**
* `*.sdt`, `*.ldt`, and `*.gdf` files produced by these writers use the new comma-delimited, single-header format and are not compatible with tRIBS versions prior to v6.0.0.
* `*.ldt`: the Gray (1970) parameters (`a`, `b1`) are removed, and a new `RZD_m` column is required (use `9999.99` to fall back to the tRIBS default).
* `write_soil_table(..., textures=True)` no longer appends a `Texture` column to the `*.sdt`; it writes a separate `*_textures.csv` sidecar. Code that read texture from the table must read the sidecar (or `read_soil_table(textures=True)`) instead.