### PR TITLE
Update met file formats for tRIBS v6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The v1.0.0 changes listed below are abbreviated. For specific details refer to t
 * **Standardized File Formats:** Reworked the soil (`.sdt`), land use (`.ldt`), and grid data (`.gdf`) readers and writers to the new single-header, comma-delimited v6.0.0 format. ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/34))
 * **Soil Textures:** Soil textures are now written to a `*_textures.csv` sidecar file instead of an extra column in the `.sdt`. ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/34))
 * **Static Land Use Grids:** Grid-file path validation now recognizes the new static gridded land use option (`OPTLANDUSE = 2`). ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/34))
+* **Solar Position Calculations:** Variables for computing the solar position have been moved from the station data files into the main input file as keywords. ([#35](https://github.com/tRIBS-Model/pytRIBS/pull/35))
+* **Forcing Data File Formats:** Reworked the precipitation/meteorological data files (`.sdf` and `.mdf`) readers and writers to the new single-header, comma-delimited v6.0.0 format. ([#35](https://github.com/tRIBS-Model/pytRIBS/pull/35))
   
 #### Removed
 * **Legacy Land Use Parameters:** Removed the Gray (1970) interception parameters (`a`, `b1`) from the land use table. ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/34))

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The v1.0.0 changes listed below are abbreviated. For specific details refer to t
 
 #### Added
 * **Snow Parameter File (`.spf`):** Snow physics constants can now be read from and written to a dedicated `.spf` file, and are loaded automatically when referenced in the main input file. ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/34))
-* **Root Zone Depth Parameter:** Added the `RZD_m` parameter to the land use table (`.ldt`). ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/XX))
+* **Root Zone Depth Parameter:** Added the `RZD_m` parameter to the land use table (`.ldt`). ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/34))
+* **Simplified Soil Data Table Creation:** Previously if a user had their own soil ID map the process to generate a soil data table (`.sdt`) was cumbersome. A new function, `create_soil_table_from_map()` was added to simplify this process. ([#35](https://github.com/tRIBS-Model/pytRIBS/pull/35))
 
 #### Changed & Refactored
 * **Standardized File Formats:** Reworked the soil (`.sdt`), land use (`.ldt`), and grid data (`.gdf`) readers and writers to the new single-header, comma-delimited v6.0.0 format. ([#34](https://github.com/tRIBS-Model/pytRIBS/pull/34))

--- a/pytRIBS/classes.py
+++ b/pytRIBS/classes.py
@@ -387,6 +387,11 @@ class Mesh:
         self.graphoption = options['graphoption']
         self.demfile = options['demfile']
 
+        # Solar position options auto-populated from the watershed centroid (see update_solar_position)
+        self.utcoffset = options['utcoffset']
+        self.centroidlat = options['centroidlat']
+        self.centroidlong = options['centroidlong']
+
 
 class Met(MetProcessor):
     """
@@ -437,3 +442,8 @@ class Met(MetProcessor):
         self.hydrometgrid = options['hydrometgrid']
         self.rainsource = options['rainsource']
         self.rainextension = options['rainextension']
+
+        # Solar position options auto-populated from the watershed centroid (see update_solar_position)
+        self.utcoffset = options['utcoffset']
+        self.centroidlat = options['centroidlat']
+        self.centroidlong = options['centroidlong']

--- a/pytRIBS/classes.py
+++ b/pytRIBS/classes.py
@@ -440,6 +440,7 @@ class Met(MetProcessor):
         self.gaugestations = options['gaugestations']
         self.rainfile = options['rainfile']
         self.hydrometgrid = options['hydrometgrid']
+        self.metdataoption = options['metdataoption']
         self.rainsource = options['rainsource']
         self.rainextension = options['rainextension']
 

--- a/pytRIBS/classes.py
+++ b/pytRIBS/classes.py
@@ -365,11 +365,12 @@ class Mesh:
         if meta is not None:
             self.meta = meta
 
+        boundary_gdf = None
         if preprocess_args is not None:  # TODO need to catch if generate_mesh_args is NONE
             self.preprocess = Preprocess(*preprocess_args)
             _, bound_path, stream_path, out_path, _ = generate_mesh_args
-            self.preprocess.extract_watershed_and_stream_network(out_path, bound_path,
-                                                                 stream_path)
+            boundary_gdf = self.preprocess.extract_watershed_and_stream_network(out_path, bound_path,
+                                                                                stream_path)
             self.meta = self.preprocess.meta
 
         if generate_mesh_args is not None:
@@ -391,6 +392,10 @@ class Mesh:
         self.utcoffset = options['utcoffset']
         self.centroidlat = options['centroidlat']
         self.centroidlong = options['centroidlong']
+
+        # If a watershed was delineated above, auto-populate the solar position keywords from it
+        if boundary_gdf is not None:
+            Aux.update_solar_position(self, boundary_gdf.geometry.iloc[0])
 
 
 class Met(MetProcessor):
@@ -443,6 +448,10 @@ class Met(MetProcessor):
         self.metdataoption = options['metdataoption']
         self.rainsource = options['rainsource']
         self.rainextension = options['rainextension']
+
+        # pytRIBS-internal naming prefix for generated met/precip output files. Not a tRIBS input                                
+        # keyword (so it is not written to the .in file); used by the met workflow.                                              
+        self.hydrometbasename = {'value': None}       
 
         # Solar position options auto-populated from the watershed centroid (see update_solar_position)
         self.utcoffset = options['utcoffset']

--- a/pytRIBS/land/land.py
+++ b/pytRIBS/land/land.py
@@ -242,65 +242,34 @@ class LandProcessor(InOut):
             })
 
         return classified_data, class_list
-    def _polygon_centroid_to_geographic(self, polygon, utm_crs=None, geographic_crs="EPSG:4326"):
-        lat,lon, gmt = Aux.polygon_centroid_to_geographic(self,polygon,utm_crs=utm_crs,geographic_crs=geographic_crs)
-        return lat, lon, gmt
 
-    def create_gdf_content(self, parameters, watershed):
+    def create_gdf_content(self, parameters):
         """
-        Create a dictionary containing geographic and parameter information for a watershed.
+        Wraps a list of grid parameters into the dictionary structure expected by
+        write_grid_data_file.
 
-        This function computes the geographic centroid of the given watershed polygon,
-        converts it to geographic coordinates (latitude and longitude), and then creates
-        a dictionary containing the number of parameters, the centroid's geographic location,
-        the GMT time zone, and a list of parameters.
+        Location and GMT information formerly stored here now lives in the main input file
+        (CENTROIDLAT, CENTROIDLONG, UTCOFFSET; see update_solar_position), so the watershed is
+        no longer needed.
 
         Parameters
         ----------
-        parameters : list of list
-            A list where each element is a list containing:
-            - parameter name (str): The name of the parameter (e.g., 'VH').
-            - raster path (str): The file path to the specified raster.
-            - file extension (str): The extension of the raster file (e.g., '.tif').
-        watershed : GeoDataFrame or shapely.geometry.Polygon
-            The watershed boundary used to compute the centroid and derive geographic coordinates.
+        parameters : list of dict
+            A list where each element is a dict describing one gridded variable with keys
+            'Variable Name', 'Raster Path', and 'Raster Extension'.
 
         Returns
         -------
         dict
-            A dictionary containing the following key-value pairs:
-            - 'Number of Parameters' : int
-                The number of parameters provided.
-            - 'Latitude' : float
-                The latitude of the watershed centroid in geographic coordinates.
-            - 'Longitude' : float
-                The longitude of the watershed centroid in geographic coordinates.
-            - 'GMT Time Zone' : int
-                The GMT time zone derived from the geographic coordinates.
-            - 'Parameters' : list
-                The original list of parameters provided.
+            A dictionary with 'Number of Parameters' and 'Parameters', ready to pass to
+            write_grid_data_file.
 
         Examples
         --------
-        To create a dictionary of geographic and parameter information for a watershed:
-
         >>> parameters = [
-        ...     ['VH', 'path/to/raster1.tif', '.tif'],
-        ...     ['NDVI', 'path/to/raster2.tif', '.tif']
+        ...     {'Variable Name': 'VH', 'Raster Path': 'path/to/VH', 'Raster Extension': 'asc'}
         ... ]
-        >>> watershed = geopandas.read_file('path/to/watershed.shp')
-        >>> gdf_content = create_gdf_content(parameters, watershed)
-        >>> print(gdf_content['Latitude'], gdf_content['Longitude'])
-
+        >>> gdf_content = land.create_gdf_content(parameters)
+        >>> land.write_grid_data_file(land.lugrid['value'], gdf_content)
         """
-
-        num_params = len(parameters)
-        lat, lon, gmt = self._polygon_centroid_to_geographic(watershed)
-
-        land_gdf_content = {'Number of Parameters': num_params,
-                            'Latitude': lat,  # update
-                            'Longitude': lon,
-                            'GMT Time Zone': gmt,
-                            'Parameters': parameters
-                            }
-        return  land_gdf_content
+        return {'Number of Parameters': len(parameters), 'Parameters': parameters}

--- a/pytRIBS/mesh/mesh.py
+++ b/pytRIBS/mesh/mesh.py
@@ -24,7 +24,6 @@ import pyvista as pv
 from shapely.ops import unary_union
 
 from pytRIBS.shared.inout import InOut
-from pytRIBS.shared.aux import Aux
 
 from pytRIBS.shared.shared_mixin import Meta, Shared
 from pytRIBS.mesh.run_docker import MeshBuilderDocker
@@ -392,10 +391,6 @@ class Preprocess:
         gdf.set_crs(epsg=self.meta["EPSG"],inplace=True)
         gdf.to_file(output_path)
 
-        # Auto-populate the solar position keywords (CENTROIDLAT/CENTROIDLONG/UTCOFFSET) from
-        # the watershed centroid. Users can still set these manually like any other option.
-        Aux.update_solar_position(self, gdf.geometry.iloc[0])
-
         return gdf, output_path
 
     def convert_stream_raster_to_vector(self, stream_raster, flow_direction_raster, output_path=None):
@@ -597,13 +592,15 @@ class Preprocess:
         outlet = self.create_outlet(self.outlet[0], self.outlet[1], flow_acc, self.snap_distance,
                                     output_path=f'{outlet_path}')
         ws_mask = self.generate_watershed_mask(d8_raster, outlet)
-        _, ws_bound = self.generate_watershed_boundary(ws_mask, output_path=f'{boundary_path}')
+        ws_gdf, ws_bound = self.generate_watershed_boundary(ws_mask, output_path=f'{boundary_path}')
         stream_shp = self.convert_stream_raster_to_vector(streams, d8_raster)
         self.clip_rasters([filled], ws_bound, output_dir=output_dir, method='both')
         self.clip_streamline(os.path.abspath(stream_shp), ws_bound, output_path=f'{output_streams_path}')
 
         if clean is True:
             shutil.rmtree(temp)
+
+        return ws_gdf
 
 
 class GenerateMesh:

--- a/pytRIBS/mesh/mesh.py
+++ b/pytRIBS/mesh/mesh.py
@@ -24,6 +24,7 @@ import pyvista as pv
 from shapely.ops import unary_union
 
 from pytRIBS.shared.inout import InOut
+from pytRIBS.shared.aux import Aux
 
 from pytRIBS.shared.shared_mixin import Meta, Shared
 from pytRIBS.mesh.run_docker import MeshBuilderDocker
@@ -390,6 +391,10 @@ class Preprocess:
             gdf = gdf.dissolve()
         gdf.set_crs(epsg=self.meta["EPSG"],inplace=True)
         gdf.to_file(output_path)
+
+        # Auto-populate the solar position keywords (CENTROIDLAT/CENTROIDLONG/UTCOFFSET) from
+        # the watershed centroid. Users can still set these manually like any other option.
+        Aux.update_solar_position(self, gdf.geometry.iloc[0])
 
         return gdf, output_path
 

--- a/pytRIBS/met/met.py
+++ b/pytRIBS/met/met.py
@@ -789,3 +789,66 @@ class MetProcessor(Aux, InOut):
                                                 orig_begin=begin, orig_end=end)
 
         return nldas_df
+
+    # Variable order for the gridded meteorological grid data file (*.gdf). XC (cloud cover) and
+    # TS (surface temperature) are optional; the rest are required (no lookup-table fallback).
+    MET_GRID_ORDER = ['PA', 'RH', 'XC', 'US', 'TA', 'IS', 'TS']
+    MET_GRID_OPTIONAL = ['XC', 'TS']
+
+    def write_met_grid(self, parameters, output_file_path=None):
+        """
+        Writes a gridded meteorological grid data file (*.gdf) and configures the model to use
+        it by setting HYDROMETGRID to the written path and METDATAOPTION to 2 (gridded met).
+
+        Unlike gridded soil/land use, gridded meteorological data has no lookup-table fallback
+        (METDATAOPTION is an exclusive switch), so every required variable must be present in the
+        grid data file. The required variables are PA, RH, US, TA, and IS. XC (cloud cover) and
+        TS (surface temperature) are optional; if not supplied they are written as NO_DATA rows.
+
+        Example
+        -------
+        >>> params = [
+        ...     {'Variable Name': 'PA', 'Raster Path': 'data/weather/PA', 'Raster Extension': 'asc'},
+        ...     {'Variable Name': 'RH', 'Raster Path': 'data/weather/RH', 'Raster Extension': 'asc'},
+        ...     {'Variable Name': 'US', 'Raster Path': 'data/weather/US', 'Raster Extension': 'asc'},
+        ...     {'Variable Name': 'TA', 'Raster Path': 'data/weather/TA', 'Raster Extension': 'asc'},
+        ...     {'Variable Name': 'IS', 'Raster Path': 'data/weather/IS', 'Raster Extension': 'asc'},
+        ... ]
+        >>> met.write_met_grid(params, 'data/weather/hydrometgrid.gdf')
+
+        :param parameters: list of dicts with keys 'Variable Name', 'Raster Path', 'Raster Extension'.
+        :param output_file_path: Path to write the *.gdf to. Defaults to the current
+            HYDROMETGRID option value if one is set.
+        """
+        if output_file_path is None:
+            output_file_path = self.hydrometgrid['value']
+            if output_file_path is None:
+                print("No output path provided and HYDROMETGRID is not set; "
+                      "provide output_file_path.")
+                return
+
+        param_map = {p['Variable Name']: p for p in parameters}
+
+        required = [v for v in self.MET_GRID_ORDER if v not in self.MET_GRID_OPTIONAL]
+        missing_required = [v for v in required if v not in param_map]
+        if missing_required:
+            print(f"Warning: gridded meteorological data has no lookup-table fallback, but these "
+                  f"required variables are missing: {', '.join(missing_required)}.")
+
+        # Emit variables in canonical order, filling optional variables with NO_DATA when absent
+        ordered = []
+        for v in self.MET_GRID_ORDER:
+            if v in param_map:
+                ordered.append(param_map[v])
+            elif v in self.MET_GRID_OPTIONAL:
+                ordered.append({'Variable Name': v, 'Raster Path': 'NO_DATA',
+                                'Raster Extension': 'NO_DATA'})
+        # Append any extra user-provided variables not part of the standard set
+        for p in parameters:
+            if p['Variable Name'] not in self.MET_GRID_ORDER:
+                ordered.append(p)
+
+        self.write_grid_data_file(output_file_path, {'Parameters': ordered})
+
+        self.hydrometgrid['value'] = output_file_path
+        self.metdataoption['value'] = 2

--- a/pytRIBS/met/met.py
+++ b/pytRIBS/met/met.py
@@ -658,7 +658,6 @@ class MetProcessor(Aux, InOut):
             # Update to tRIBS variables
             df['XC'] = 9999.99
             df['TS'] = 9999.99
-            df['NR'] = 9999.99
             df['psurf'] *= 0.01  # Convert pressure from Pa to hPa
 
             # Calculate Wind Speed
@@ -699,7 +698,7 @@ class MetProcessor(Aux, InOut):
             met_file_path = os.path.join(met_dir, met_file)
 
             self.write_precip_station(df[['R', 'date']].copy(), precip_file_path)
-            self.write_met_station(df[['PA', 'RH', 'XC', 'TS', 'NR', 'TA', 'US', 'VP', 'IS', 'date']].copy(),
+            self.write_met_station(df[['PA', 'RH', 'XC', 'TS', 'TA', 'US', 'IS', 'date']].copy(),
                                     met_file_path)
 
             # Update sdf dictionaries
@@ -767,6 +766,11 @@ class MetProcessor(Aux, InOut):
         lat, lon, gmt = self.polygon_centroid_to_geographic(watershed)
         x, y = watershed.centroid.x, watershed.centroid.y
         centroids = [(x,y)]
+
+        # Store the centroid and UTC offset for tRIBS solar position calculations
+        self.centroidlat['value'] = lat
+        self.centroidlong['value'] = lon
+        self.utcoffset['value'] = gmt
 
         if elev is None:
             print("No elevation provided. Downloading NLDAS-2 elevation grid...")

--- a/pytRIBS/met/met.py
+++ b/pytRIBS/met/met.py
@@ -622,8 +622,6 @@ class MetProcessor(Aux, InOut):
 
         # Hard coded params for writing
         count = 1
-        num_params_precip = 5
-        num_params_met = 12
 
         # Physical constants
         L = 2.453 * 10 ** 6  # Latent heat of vaporization (J/kg)
@@ -654,10 +652,8 @@ class MetProcessor(Aux, InOut):
                 df = df.loc[orig_begin:orig_end].copy()
 
             # Initialize dictionaries for station details
-            met_sdf = {'station_id': None, 'file_path': None, 'lat_dd': None, 'y': None, 'long_dd': None, 'x': None,
-                       'GMT': None, 'record_length': None, 'num_parameters': None, 'other': None}
-            precip_sdf = {'station_id': None, 'file_path': None, 'y': None, 'x': None, 'record_length': None,
-                          'num_parameters': None, 'elevation': None}
+            met_sdf = {'station_id': None, 'file_path': None, 'y': None, 'x': None, 'elevation': None}
+            precip_sdf = {'station_id': None, 'file_path': None, 'y': None, 'x': None, 'elevation': None}
 
             # Update to tRIBS variables
             df['XC'] = 9999.99
@@ -712,38 +708,25 @@ class MetProcessor(Aux, InOut):
             met_sdf['file_path'] = met_file_path
             precip_sdf['file_path'] = precip_file_path
 
-            # Geographic coordinates
-            lat = station_coords[count - 1][2]
+            # Geographic coordinates (UTM northing/easting) and elevation
             y = station_coords[count - 1][3]
-            long = station_coords[count - 1][0]
             x = station_coords[count - 1][1]
-
-            met_sdf['lat_dd'] = lat
-            met_sdf['long_dd'] = long
+            elevation = station_coords[count - 1][4]
 
             met_sdf['x'] = x
             met_sdf['y'] = y
             precip_sdf['x'] = x
             precip_sdf['y'] = y
 
-            met_sdf['GMT'] = gmt
-            precip_sdf['elevation'] = station_coords[count - 1][4]
-            met_sdf['other'] = station_coords[count - 1][4]
-
-            met_sdf['num_parameters'] = num_params_met
-            precip_sdf['num_parameters'] = num_params_precip
-
-            length = len(df['date'])
-
-            met_sdf['record_length'] = length
-            precip_sdf['record_length'] = length
+            met_sdf['elevation'] = elevation
+            precip_sdf['elevation'] = elevation
 
             met_sdf_list.append(met_sdf)
             precip_sdf_list.append(precip_sdf)
 
             count += 1
 
-        self.write_met_sdf(met_path, met_sdf_list)
+        self.write_met_sdf(met_sdf_list, met_path)
         self.write_precip_sdf(precip_sdf_list, precip_path)
 
     def run_met_workflow(self, watershed, begin, end, elev=None):

--- a/pytRIBS/model/model.py
+++ b/pytRIBS/model/model.py
@@ -46,7 +46,7 @@ class ModelProcessor:
             # (1) includes base name and not actual path
             # (2) tRIBS will error out if it doesn't exist, but won't tell you explicitly why.
 
-            if item["key_word"] == "OUTFILENAME:":
+            if item["keyword"] == "OUTFILENAME:":
                 print("Checking OUTFILENAME:")
                 path = item["value"]
                 index = path.rfind('/')  # Find the last occurrence of '/'
@@ -63,7 +63,7 @@ class ModelProcessor:
                 else:
                     print("Warning!!! Path for OUTFILENAME: does not exist")
 
-            if item["value"] is not None:
+            if isinstance(item["value"], str):
                 flag = os.path.exists(item["value"])
                 if flag:
                     exists.append(item)
@@ -72,7 +72,7 @@ class ModelProcessor:
 
         print("\nThe following tRIBS inputs do not have paths that exist: \n")
         for item in doesnt:
-            print(f"{item['key_word']} {item['describe']}")
+            print(f"{item['keyword']} {item['describe']}")
 
         print("\nChecking if station descriptor paths exist.\n")
         rain = instance.read_precip_sdf()

--- a/pytRIBS/shared/aux.py
+++ b/pytRIBS/shared/aux.py
@@ -122,6 +122,24 @@ class Aux:
 
         return lat, lon, gmt_offset
 
+    def update_solar_position(self, watershed):
+        """
+        Computes the watershed centroid (latitude, longitude) and its UTC offset and stores them
+        in the CENTROIDLAT, CENTROIDLONG, and UTCOFFSET input-file options. tRIBS uses these for
+        solar position calculations. These keywords can also be set manually like any other
+        option; this helper is the auto-populating path used by the delineation and met workflows.
+
+        :param watershed: A Shapely polygon of the watershed. The centroid is used.
+        """
+        result = Aux.polygon_centroid_to_geographic(self, watershed)
+        if result is None:
+            return
+
+        lat, lon, gmt = result
+        self.centroidlat['value'] = lat
+        self.centroidlong['value'] = lon
+        self.utcoffset['value'] = gmt
+
     def utm_to_latlong(self, easting, northing, epsg=None):
         """
         Convert UTM coordinates to latitude and longitude using an EPSG code with pyproj.

--- a/pytRIBS/shared/infile_mixin.py
+++ b/pytRIBS/shared/infile_mixin.py
@@ -57,6 +57,13 @@ class Infile:
             "rainsearch": {"keyword": "RAINSEARCH:", "describe": "Rainfall search interval (hours)", "value": 24,
                            "tags": ["time"], "section": 1, "subsection": "Time Variables"},
 
+            "utcoffset": {"keyword": "UTCOFFSET:", "describe": "UTC (GMT) offset of the watershed centroid, used for solar position calculations (hours)",
+                          "value": None, "tags": ["time"], "section": 1, "subsection": "Solar Position Variables"},
+            "centroidlat": {"keyword": "CENTROIDLAT:", "describe": "Latitude of the watershed centroid, used for solar position calculations (decimal degrees)",
+                            "value": None, "tags": ["location"], "section": 1, "subsection": "Solar Position Variables"},
+            "centroidlong": {"keyword": "CENTROIDLONG:", "describe": "Longitude of the watershed centroid, used for solar position calculations (decimal degrees)",
+                             "value": None, "tags": ["location"], "section": 1, "subsection": "Solar Position Variables"},
+
             # ==================================================================================================
             # ROUTING PARAMETERS
             # ==================================================================================================

--- a/pytRIBS/shared/infile_mixin.py
+++ b/pytRIBS/shared/infile_mixin.py
@@ -60,9 +60,9 @@ class Infile:
             "utcoffset": {"keyword": "UTCOFFSET:", "describe": "UTC (GMT) offset of the watershed centroid, used for solar position calculations (hours)",
                           "value": None, "tags": ["time"], "section": 1, "subsection": "Solar Position Variables"},
             "centroidlat": {"keyword": "CENTROIDLAT:", "describe": "Latitude of the watershed centroid, used for solar position calculations (decimal degrees)",
-                            "value": None, "tags": ["location"], "section": 1, "subsection": "Solar Position Variables"},
+                            "value": None, "tags": ["solar"], "section": 1, "subsection": "Solar Position Variables"},
             "centroidlong": {"keyword": "CENTROIDLONG:", "describe": "Longitude of the watershed centroid, used for solar position calculations (decimal degrees)",
-                             "value": None, "tags": ["location"], "section": 1, "subsection": "Solar Position Variables"},
+                             "value": None, "tags": ["solar"], "section": 1, "subsection": "Solar Position Variables"},
 
             # ==================================================================================================
             # ROUTING PARAMETERS

--- a/pytRIBS/shared/inout.py
+++ b/pytRIBS/shared/inout.py
@@ -344,11 +344,11 @@ class InOut:
     def read_precip_station(file_path):
         """
         Returns pandas dataframe of precipitation from a station specified by file_path.
-        :param file_path: Flat file with columns Y M D H R
+        :param file_path: tRIBS precip data file (*.mdf), comma-delimited with header Y,M,D,H,R
         :return: Pandas dataframe
         """
         # TODO add var for specifying Station ID
-        df = pd.read_csv(file_path, header=0, sep=r"\s+")
+        df = pd.read_csv(file_path, header=0, sep=',')
         df.rename(columns={'Y': 'year', 'M': 'month', 'D': 'day', 'H': 'hour'}, inplace=True)
         df['date'] = pd.to_datetime(df[['year', 'month', 'day', 'hour']])
         df.drop(['year', 'month', 'day', 'hour'], axis=1, inplace=True)
@@ -385,9 +385,10 @@ class InOut:
     @staticmethod
     def write_precip_station(df, output_file_path):
         """
-        Converts a DataFrame with 'date' and 'R' columns to flat file format with columns Y M D H R.
+        Converts a DataFrame with 'date' and 'R' columns to the tRIBS precip data file
+        (*.mdf) format: comma-delimited with header Y,M,D,H,R.
         :param df: Pandas DataFrame with 'date' and 'R' columns.
-        :param output_file_path: Output flat file path.
+        :param output_file_path: Output *.mdf path.
         """
         # Extract Y, M, D, and H from the 'date' column
         df['Y'] = df['date'].dt.year
@@ -399,7 +400,7 @@ class InOut:
         df = df[['Y', 'M', 'D', 'H', 'R']]
 
         # Write DataFrame to flat file
-        df.to_csv(output_file_path, sep=' ', index=False)
+        df.to_csv(output_file_path, sep=',', index=False)
 
     def read_met_sdf(self, file_path=None):
         """
@@ -425,57 +426,68 @@ class InOut:
         Parameters
         ----------
         file_path : str
-            Path to the meteorological station data file. The file should be in a space-separated format with columns for
-            year, month, day, and hour.
+            Path to the *.mdf file. The file is comma-delimited with the header
+            Year,Month,Day,Hour,PA_mb,RH_pct,XC_tenths,US_m/s,TA_C,IS_W/m2,TS_C.
 
         Returns
         -------
         pandas.DataFrame
-            A DataFrame containing the meteorological data with a single 'date' column as a datetime index, and the remaining
-            columns from the input file.
+            A DataFrame with a single 'date' column built from Year/Month/Day/Hour, and the
+            meteorological variables under their short names: PA, RH, XC, US, TA, IS, TS.
 
         Notes
         -----
-        - The function expects the input file to have columns 'Y', 'M', 'D', and 'H' for year, month, day, and hour, respectively.
-        - The columns for year, month, day, and hour are converted into a single 'date' column of datetime type.
-        - The original columns 'Y', 'M', 'D', and 'H' are dropped from the DataFrame after the datetime conversion.
+        - The descriptive, unit-bearing header columns are mapped to the short variable names.
+        - Year/Month/Day/Hour are combined into a single 'date' column and dropped.
         """
-        # TODO add var for specifying Station ID and doc
-        df = pd.read_csv(file_path, header=0, sep=r'\s+')
-        # convert year, month, day to datetime and drop columns
-        df.rename(columns={'Y': 'year', 'M': 'month', 'D': 'day', 'H': 'hour'}, inplace=True)
+        df = pd.read_csv(file_path, header=0, sep=',')
+        df.rename(columns={'Year': 'year', 'Month': 'month', 'Day': 'day', 'Hour': 'hour',
+                           'PA_mb': 'PA', 'RH_pct': 'RH', 'XC_tenths': 'XC', 'US_m/s': 'US',
+                           'TA_C': 'TA', 'IS_W/m2': 'IS', 'TS_C': 'TS'}, inplace=True)
         df['date'] = pd.to_datetime(df[['year', 'month', 'day', 'hour']])
         df = df.drop(['year', 'month', 'day', 'hour'], axis=1)
         return df
+
     @staticmethod
     def write_met_station(df, output_file_path):
         """
-        Converts a DataFrame with 'date' and 'PA','TD' or 'RH' or 'VP','XC','US','TA','TS','NR' columns to flat file format.
-        See tRIBS documentation for more details on weather station data structure (i.e. *mdf files).
-        :param df: Pandas DataFrame with 'date' and 'R' columns.
-        :param output_file_path: Output flat file path.
+        Converts a DataFrame with a 'date' column and meteorological variables to the tRIBS 
+         meteorological data file (*.mdf) format: comma-delimited with the header
+        Year,Month,Day,Hour,PA_mb,RH_pct,XC_tenths,US_m/s,TA_C,IS_W/m2,TS_C.
+
+        Relative humidity (RH) is the only accepted humidity input in v6.0.0; the pre-v6.0.0
+        TD/VP alternatives and the unused net radiation (NR) column have been removed. Cloud
+        cover (XC) and surface temperature (TS) are required columns but are typically 9999.99;
+        if absent from df they are written as 9999.99.
+
+        :param df: Pandas DataFrame with a 'date' column and at least 'PA', 'RH', 'US', 'TA',
+            and 'IS' columns.
+        :param output_file_path: Output *.mdf path.
         """
-        # Extract Y, M, D, and H from the 'date' column
-        df['Y'] = df['date'].dt.year
-        df['M'] = df['date'].dt.month
-        df['D'] = df['date'].dt.day
-        df['H'] = df['date'].dt.hour
+        if 'RH' not in df.columns:
+            print("Error: 'RH' (relative humidity) is required for the v6.0.0 met data file.")
+            return
 
-        # Format 'D' and 'H' columns with zero-padding
-        df['D'] = df['D'].apply(lambda x: str(x).zfill(2))
-        df['H'] = df['H'].apply(lambda x: str(x).zfill(2))
+        df = df.copy()
 
-        # Check which column ('TD', 'RH', or 'VP') is present in the DataFrame
-        present_column = next((col for col in ['TD', 'RH', 'VP'] if col in df.columns), None)
+        # Extract Year, Month, Day, Hour from the 'date' column
+        df['Year'] = df['date'].dt.year
+        df['Month'] = df['date'].dt.month
+        df['Day'] = df['date'].dt.day
+        df['Hour'] = df['date'].dt.hour
 
-        if present_column is not None:
-            # Reorder columns
-            df = df[['Y', 'M', 'D', 'H', 'PA', present_column, 'XC', 'US', 'TA', 'IS', 'TS', 'NR']]
+        # XC and TS are required columns but are typically the 9999.99 fill value
+        if 'XC' not in df.columns:
+            df['XC'] = 9999.99
+        if 'TS' not in df.columns:
+            df['TS'] = 9999.99
 
-            # Write DataFrame to flat file with tab as separator
-            df.to_csv(output_file_path, sep='\t', index=False)
-        else:
-            print("Error: One of 'TD', 'RH', or 'VP' column must be present in the DataFrame.")
+        columns = ['Year', 'Month', 'Day', 'Hour', 'PA', 'RH', 'XC', 'US', 'TA', 'IS', 'TS']
+        header = 'Year,Month,Day,Hour,PA_mb,RH_pct,XC_tenths,US_m/s,TA_C,IS_W/m2,TS_C'
+
+        with open(output_file_path, 'w') as f:
+            f.write(header + '\n')
+            df[columns].to_csv(f, header=False, index=False)
 
 
     @staticmethod

--- a/pytRIBS/shared/inout.py
+++ b/pytRIBS/shared/inout.py
@@ -522,7 +522,7 @@ class InOut:
             file_path = self.landtablename["value"]
 
             if file_path is None:
-                print(self.landtablename["key_word"] + "is not specified.")
+                print(self.landtablename["keyword"] + " is not specified.")
                 return
 
         landuse_list = []
@@ -561,6 +561,12 @@ class InOut:
             else:
                 print(f"Skipping row in {file_path}: expected {param_standard} comma-separated "
                       f"values, got {len(land_info)}.")
+
+        if not landuse_list:
+            print(f"Warning: no land use entries were read from {file_path}. Confirm it is in the "
+                  f"tRIBS v6.0.0 format (one descriptive header line, then comma-delimited rows). "
+                  f"Pre-v6.0.0 tables (a count line with whitespace-delimited rows) are not "
+                  f"compatible and must be converted.")
 
         return landuse_list
     @staticmethod

--- a/pytRIBS/shared/inout.py
+++ b/pytRIBS/shared/inout.py
@@ -282,47 +282,63 @@ class InOut:
                     self.snow_options[key]['value'] = lines[i + 1].strip()
             i += 1
 
-    def read_precip_sdf(self, file_path=None):
+    @staticmethod
+    def read_sdf(file_path):
         """
-        Returns list of precip stations, where information from each station is stored in a dictionary.
-        :param file_path: Reads from options["hydrometstations"]["value"], but can be separately specified.
-        :return: List of dictionaries.
+        Reads a tRIBS station descriptor file (*.sdf) and returns a list of station
+        dictionaries. Both the precipitation and hydrometeorological station files share this
+        format: a single descriptive header line that tRIBS skips, followed by comma-delimited
+        rows of ID,DataFile,Northing,Easting,Elevation:
+
+        ID,DataFile,Northing,Easting,Elevation
+        1,data/model/precip/precip_U.mdf,3891469.290931,400109.778323,2188.5
+
+        :param file_path: Path to the *.sdf file.
+        :return: List of dictionaries, one per station, with keys 'station_id', 'file_path',
+            'y' (northing), 'x' (easting), and 'elevation'.
         """
-
-        if file_path is None:
-            file_path = self.options["gaugestations"]["value"]
-
-            if file_path is None:
-                print(self.options["gaugestations"]["key_word"] + "is not specified.")
-                return None
-
         station_list = []
 
         with open(file_path, 'r') as file:
             lines = file.readlines()
 
-        metadata = lines.pop(0)
-        num_stations, num_parameters = map(int, metadata.strip().split())
+        lines.pop(0)  # discard the descriptive header line (skipped by tRIBS)
 
         for l in lines:
-            station_info = l.strip().split()
-            if len(station_info) == 7:
-                station_id, file_path, lat, long, record_length, num_params, elevation = station_info
-                station = {
-                    "station_id": station_id,
-                    "file_path": file_path,
-                    "y": float(lat),
-                    "x": float(long),
-                    "record_length": int(record_length),
-                    "num_parameters": int(num_params),
-                    "elevation": float(elevation)
-                }
-                station_list.append(station)
+            if not l.strip():
+                continue
 
-        if len(station_list) != num_stations:
-            print("Error: Number of stations does not match the specified count.")
+            info = [v.strip() for v in l.strip().split(',')]
+            if len(info) == 5:
+                station_id, data_file, northing, easting, elevation = info
+                station_list.append({
+                    "station_id": station_id,
+                    "file_path": data_file,
+                    "y": float(northing),
+                    "x": float(easting),
+                    "elevation": float(elevation)
+                })
+            else:
+                print(f"Skipping row in {file_path}: expected 5 comma-separated values, "
+                      f"got {len(info)}.")
 
         return station_list
+
+    def read_precip_sdf(self, file_path=None):
+        """
+        Returns list of precip stations read from the *.sdf referenced by the GAUGESTATIONS
+        option (or a separately specified file_path). See read_sdf for the file format.
+        :param file_path: Defaults to options["gaugestations"]["value"].
+        :return: List of dictionaries.
+        """
+        if file_path is None:
+            file_path = self.options["gaugestations"]["value"]
+
+            if file_path is None:
+                print(self.options["gaugestations"]["keyword"] + " is not specified.")
+                return None
+
+        return self.read_sdf(file_path)
 
     @staticmethod
     def read_precip_station(file_path):
@@ -340,22 +356,31 @@ class InOut:
         return df
 
     @staticmethod
-    def write_precip_sdf(station_list, output_file_path):
+    def write_sdf(station_list, output_file_path):
         """
-        Writes a list of precip stations to a flat file.
-        :param station_list: List of dictionaries containing station information.
-        :param output_file_path: Output flat file path.
+        Writes a list of station dictionaries to a tRIBS v6.0.0 station descriptor file (*.sdf):
+        a single descriptive header line (skipped by tRIBS) followed by comma-delimited rows of
+        ID,DataFile,Northing,Easting,Elevation. Used for both precipitation and
+        hydrometeorological station files.
+
+        :param station_list: List of dictionaries with keys 'station_id', 'file_path',
+            'y' (northing), 'x' (easting), and 'elevation'.
+        :param output_file_path: Output *.sdf path.
         """
         with open(output_file_path, 'w') as file:
-            # Write metadata line
-            metadata = f"{len(station_list)} {len(station_list[0])}\n"
-            file.write(metadata)
-
-            # Write station information
+            file.write("ID,DataFile,Northing,Easting,Elevation\n")
             for station in station_list:
-                line = f"{station['station_id']} {station['file_path']} {station['y']} {station['x']} " \
-                       f"{station['record_length']} {station['num_parameters']} {station['elevation']}\n"
-                file.write(line)
+                file.write(f"{station['station_id']},{station['file_path']},"
+                           f"{station['y']},{station['x']},{station['elevation']}\n")
+
+    @staticmethod
+    def write_precip_sdf(station_list, output_file_path):
+        """
+        Writes a list of precip stations to a *.sdf file. See write_sdf for the file format.
+        :param station_list: List of dictionaries containing station information.
+        :param output_file_path: Output *.sdf path.
+        """
+        InOut.write_sdf(station_list, output_file_path)
 
     @staticmethod
     def write_precip_station(df, output_file_path):
@@ -378,48 +403,19 @@ class InOut:
 
     def read_met_sdf(self, file_path=None):
         """
-        Returns list of met stations, where information from each station is stored in a dictionary.
-        :param file_path: Reads from options["hydrometstations"]["value"], but can be separately specified.
+        Returns list of met stations read from the *.sdf referenced by the HYDROMETSTATIONS
+        option (or a separately specified file_path). See read_sdf for the file format.
+        :param file_path: Defaults to options["hydrometstations"]["value"].
         :return: List of dictionaries.
         """
         if file_path is None:
             file_path = self.options["hydrometstations"]["value"]
 
             if file_path is None:
-                print(self.options["hydrometstations"]["key_word"] + "is not specified.")
+                print(self.options["hydrometstations"]["keyword"] + " is not specified.")
                 return None
 
-        station_list = []
-
-        with open(file_path, 'r') as file:
-            lines = file.readlines()
-
-        metadata = lines.pop(0)
-        num_stations, num_parameters = map(int, metadata.strip().split())
-
-        for l in lines:
-            station_info = l.strip().split()
-
-            if len(station_info) == 10:
-                station_id, file_path, lat, y, long, x, gmt, record_length, num_params, other = station_info
-                station = {
-                    "station_id": station_id,
-                    "file_path": file_path,
-                    "lat_dd": float(lat),
-                    "x": float(x),
-                    "long_dd": float(long),
-                    "y": float(y),
-                    "GMT": int(gmt),
-                    "record_length": int(record_length),
-                    "num_parameters": int(num_params),
-                    "other": other
-                }
-                station_list.append(station)
-
-        if len(station_list) != num_stations:
-            print("Error: Number of stations does not match the specified count.")
-
-        return station_list
+        return self.read_sdf(file_path)
 
     @staticmethod
     def read_met_station(file_path):
@@ -483,22 +479,18 @@ class InOut:
 
 
     @staticmethod
-    def write_met_sdf(output_file_path, station_list):
+    def write_met_sdf(station_list, output_file_path):
         """
-        Writes a list of meteorological stations to a flat file (i.e. *.sdf file).
-        :param station_list: List of dictionaries containing station information.
-        :param output_file_path: Output flat file path.
-        """
-        with open(output_file_path, 'w') as file:
-            # Write metadata line
-            metadata = f"{len(station_list)} {len(station_list[0])}\n"
-            file.write(metadata)
+        Writes a list of meteorological stations to a *.sdf file. See write_sdf for the file
+        format.
 
-            # Write station information
-            for station in station_list:
-                line = f"{station['station_id']} {station['file_path']} {station['lat_dd']} {station['y']} {station['long_dd']} {station['x']} " \
-                       f"{station['GMT']} {station['record_length']} {station['num_parameters']} {station['other']}\n"
-                file.write(line)
+        Note: the argument order changed in v1.0.0 to (station_list, output_file_path) to match
+        write_precip_sdf.
+
+        :param station_list: List of dictionaries containing station information.
+        :param output_file_path: Output *.sdf path.
+        """
+        InOut.write_sdf(station_list, output_file_path)
 
     def read_landuse_table(self, file_path=None):
         """

--- a/pytRIBS/shared/inout.py
+++ b/pytRIBS/shared/inout.py
@@ -358,7 +358,7 @@ class InOut:
     @staticmethod
     def write_sdf(station_list, output_file_path):
         """
-        Writes a list of station dictionaries to a tRIBS v6.0.0 station descriptor file (*.sdf):
+        Writes a list of station dictionaries to a tRIBS station descriptor file (*.sdf):
         a single descriptive header line (skipped by tRIBS) followed by comma-delimited rows of
         ID,DataFile,Northing,Easting,Elevation. Used for both precipitation and
         hydrometeorological station files.
@@ -465,7 +465,7 @@ class InOut:
         :param output_file_path: Output *.mdf path.
         """
         if 'RH' not in df.columns:
-            print("Error: 'RH' (relative humidity) is required for the v6.0.0 met data file.")
+            print("Error: 'RH' (relative humidity) is required for the met data file.")
             return
 
         df = df.copy()
@@ -564,7 +564,7 @@ class InOut:
 
         if not landuse_list:
             print(f"Warning: no land use entries were read from {file_path}. Confirm it is in the "
-                  f"tRIBS v6.0.0 format (one descriptive header line, then comma-delimited rows). "
+                  f"tRIBS format (one descriptive header line, then comma-delimited rows). "
                   f"Pre-v6.0.0 tables (a count line with whitespace-delimited rows) are not "
                   f"compatible and must be converted.")
 

--- a/pytRIBS/soil/soil.py
+++ b/pytRIBS/soil/soil.py
@@ -171,7 +171,7 @@ class SoilProcessor:
             file_path = self.soiltablename["value"]
 
             if file_path is None:
-                print(self.soiltablename["key_word"] + "is not specified.")
+                print(self.soiltablename["keyword"] + " is not specified.")
                 return None
 
         soil_list = []
@@ -208,6 +208,12 @@ class SoilProcessor:
             else:
                 print(f"Skipping row in {file_path}: expected {param_standard} comma-separated "
                       f"values, got {len(soil_info)}.")
+
+        if not soil_list:
+            print(f"Warning: no soil entries were read from {file_path}. Confirm it is in the tRIBS "
+                  f"correct format (one descriptive header line, then comma-delimited rows). "
+                  f"Pre-v6.0.0 tables (a count line with whitespace-delimited rows) are not "
+                  f"compatible and must be converted.")
 
         if textures:
             texture_file = f"{os.path.splitext(file_path)[0]}_textures.csv"
@@ -286,6 +292,68 @@ class SoilProcessor:
                     file.write(f"{type['ID']},{type['Texture']}\n")
             print(f"Soil texture reference written to {texture_file}. This file is for user "
                   f"reference only and is not read by tRIBS.")
+
+    def create_soil_table_from_map(self, soil_map=None, textures=None):
+        """
+        Builds a soil reclassification table scaffold from an existing soil ID map (raster).
+
+        Reads the soil map, extracts the unique class IDs, and returns a list of dictionaries
+        (one per class) with the 'ID' set and every soil parameter left as None for the user to
+        fill in. This is the counterpart to create_soil_map (which derives both a map and a table
+        from gridded sand/clay data); use this when you already have a classified soil ID map and
+        just need a table to populate.
+
+        Parameters
+        ----------
+        soil_map : str, optional
+            Path to the soil ID map raster. Defaults to self.soilmapname['value'].
+        textures : dict, optional
+            Optional mapping of class ID (as a string) to a texture label. When provided, each
+            class dictionary gets a 'Texture' entry (None if its ID is not in the mapping). Those
+            labels are written to the soils_textures.csv sidecar by write_soil_table(textures=True).
+
+        Returns
+        -------
+        list of dict or None
+            One dictionary per soil class with 'ID' and the soil parameters (Ks, thetaS, thetaR,
+            m, PsiB, f, As, Au, n, ks, Cs) initialized to None, plus 'Texture' if a textures
+            mapping was provided. Returns None if no soil map is available.
+
+        Examples
+        --------
+        >>> soil.soilmapname['value'] = 'soil_classes.soi'
+        >>> soil_table = soil.create_soil_table_from_map(textures={'1': 'sandy_loam'})
+        >>> for cls in soil_table:
+        ...     cls['Ks'] = 3.6  # fill in parameters per class
+        >>> soil.write_soil_table(soil_table, soil.soiltablename['value'], textures=True)
+        """
+        if soil_map is None:
+            soil_map = self.soilmapname['value']
+            if soil_map is None:
+                print(self.soilmapname['keyword'] + " is not specified.")
+                return None
+
+        raster = self._read_ascii(soil_map)
+        nodata = raster['profile'].get('nodata')
+
+        ids = np.unique(raster['data'])
+        if nodata is not None:
+            ids = ids[ids != nodata]
+        ids = ids[np.isfinite(ids.astype(float))]  # drop NaN/inf
+
+        params = ['Ks', 'thetaS', 'thetaR', 'm', 'PsiB', 'f', 'As', 'Au', 'n', 'ks', 'Cs']
+
+        soil_table = []
+        for i in ids:
+            cid = str(int(i))
+            cls = {'ID': cid}
+            for p in params:
+                cls[p] = None
+            if textures is not None:
+                cls['Texture'] = textures.get(cid)
+            soil_table.append(cls)
+
+        return soil_table
 
     def get_soil_grids(self, bbox, depths, soil_vars, stats, replace=False):
         def retrieve_soil_data(self, bbox, depths, soil_vars, stats):


### PR DESCRIPTION
This pull request migrates the tRIBS meteorological station descriptor files (`*.sdf`) and the meteorological/precipitation data files (`*.mdf`) to the new tRIBS v6.0.0 format, relocates the solar position inputs into the main input file, and adds helpers for gridded meteorological input and for building a soil table from an existing soil map.

Previously, the station descriptor files began with a type/parameter count line followed by whitespace-delimited rows carrying latitude/longitude, GMT offset, and record-length metadata, and the data files were whitespace-delimited. tRIBS v6.0.0 standardizes the station and data files on a single header line followed by comma-delimited rows, and the location/GMT information that used to live in those files now lives in the main input file. This PR updates the readers and writers to match and adds the supporting workflow pieces.

**Technical Changes**
* `inout.py`: Merged the separate precipitation and meteorological `*.sdf` readers/writers into shared `read_sdf()`/`write_sdf()` helpers using the new `ID,DataFile,Northing,Easting,Elevation` format. `read_precip_sdf()`/`read_met_sdf()` remain as thin wrappers that resolve the `GAUGESTATIONS`/`HYDROMETSTATIONS` default paths. 
* `inout.py`: Rewrote `read_precip_station()`/`write_precip_station()` (`*.mdf`) to the comma-delimited `Y,M,D,H,R` format.
* `inout.py`: Rewrote `read_met_station()`/`write_met_station()` (`*.mdf`) to the comma-delimited humidity input (the pre-v6.0.0 `TD`/`VP` alternatives were removed), the unused net-radiation (`NR`) column was removed, and surface temperature (`TS`) is now a required column (written as `9999.99` when not supplied).
* `infile_mixin.py`: Added the `UTCOFFSET`, `CENTROIDLAT`, and `CENTROIDLONG` keywords (Section 1, "Solar Position Variables"). These hold the watershed centroid and UTC offset that tRIBS uses for solar position calculations, replacing values that previously lived in the station/grid files.
* `aux.py`: Added `update_solar_position(watershed)`, which computes the watershed centroid and populates the three solar position keywords.
* `classes.py` / `mesh.py` / `met.py`: The solar position keywords are auto-populated when a watershed is delineated (`Mesh`) and during `run_met_workflow()`, and can still be set manually like any other keyword.
* `met.py`: Added `Met.write_met_grid()` to write a gridded meteorological grid data file (`*.gdf`). It validates the required variables (`PA`, `RH`, `US`, `TA`, `IS`), writes optional `XC`/`TS` as `NO_DATA` rows, and sets `HYDROMETGRID` and `METDATAOPTION = 2` automatically.
* `soil/soil.py`: Added `Soil.create_soil_table_from_map()`, which builds a soil reclassification table scaffold (class IDs with empty parameter slots, plus optional texture labels) from an existing classified soil ID map. Essentially, the counterpart to `create_soil_map()`.
* `land/land.py`: Simplified `create_gdf_content()` to take only `parameters` and return `{Number of Parameters, Parameters}`; the `watershed` argument and the now-unused latitude/longitude/GMT keys were removed, since that information now lives in the main input file.
  
**Bug Fixes (found during testing)**
* `model.py` / `inout.py` / `soil/soil.py`: Fixed stale `key_word` references that should be `keyword` (in `check_paths()` and the soil/land table "not specified" branches), which raised `KeyError` after the input-file keyword rename.
* `model.py`: `check_paths()` now only calls `os.path.exists()` on string values.
* `soil/soil.py` / `inout.py`: `read_soil_table()` and `read_landuse_table()` now print a clear warning when zero valid rows are parsed, flagging a incompatible file instead of silently returning an empty list.
  
**Breaking Changes**
* `*.sdf` files use the new comma-delimited, single-header format (`ID,DataFile,Northing,Easting,Elevation`); the latitude/longitude, GMT, record-length, and parameter-count fields are removed. Files are not compatible with tRIBS versions prior to v6.0.0.
* `*.mdf` meteorological files: `RH` is the only accepted humidity input (`TD`/`VP` removed), the `NR` column is removed, and `TS` is now required. `*.mdf` precipitation files are now comma-delimited. 
* `write_met_sdf()` signature changed to `write_met_sdf(station_list, output_file_path)` to match `write_precip_sdf()`.
* `create_gdf_content()` signature changed to `create_gdf_content(parameters)`; the `watershed` argument was removed.