### PR TITLE
refactor: Update main input file keywords and structure for tRIBS v6.0.0

### DIFF
--- a/pytRIBS/mesh/mesh.py
+++ b/pytRIBS/mesh/mesh.py
@@ -168,7 +168,7 @@ class Preprocess:
         if output_path is None:
             output_path = f'{self.output_dir}/{name}_filled.tif'
 
-        wbt.fill_depressions(self.dem_preprocessing, os.path.abspath(output_path), fix_flats=True)
+        wbt.fill_depressions_wang_and_liu(self.dem_preprocessing, os.path.abspath(output_path), fix_flats=True)
 
         return output_path
 

--- a/pytRIBS/results/read.py
+++ b/pytRIBS/results/read.py
@@ -16,7 +16,7 @@ class Read():
         This method reads a `.qout` file containing outlet discharge and water level data, parses it into a DataFrame, and converts
         the time information from hours since the start date to actual timestamps.
 
-        The `.qout` file is expected to be named by appending `'_Outlet.qout'` to the value of the `"outhydrofilename"` option
+        The `.qout` file is expected to be named by appending `'_Outlet.qout'` to the value of the `"outfilename"` option
         from the `self.options` dictionary.
 
         The method performs the following steps:
@@ -34,7 +34,7 @@ class Read():
             - `Time` is the converted timestamp corresponding to each time step.
         """
         # currently only read for outlet, neet to add for hydronodelist
-        qout_file = self.options["outhydrofilename"]["value"]+'_Outlet.qout'
+        qout_file = self.options["outfilename"]["value"]+'_Outlet.qout'
         qout_df = pd.read_csv(qout_file, header=None, names=['Time_hr', 'Qstrm_m3s', 'Hlev_m'], skiprows=1, sep='\t')
 
         starting_date = self.options["startdate"]["value"]
@@ -46,7 +46,7 @@ class Read():
         """
         Reads and processes the `.mrf` file containing model results.
 
-        If `mrf_file` is not provided, constructs the filename using the value of the `"outhydrofilename"` option
+        If `mrf_file` is not provided, constructs the filename using the value of the `"outfilename"` option
         from `self.options`, combined with the runtime value, and appends `"_00.mrf"` to it.
 
         This method performs the following steps:
@@ -59,7 +59,7 @@ class Read():
         Parameters
         ----------
         mrf_file : str, optional
-            The path to the `.mrf` file. If not provided, the filename is constructed based on the `"outhydrofilename"` and `"runtime"`
+            The path to the `.mrf` file. If not provided, the filename is constructed based on the `"outfilename"` and `"runtime"`
             options from `self.options`.
 
         Returns
@@ -73,7 +73,7 @@ class Read():
             while len(runtime) < 4:
                 runtime = '0' + runtime
 
-            mrf_file = self.options["outhydrofilename"]["value"] + runtime + "_00.mrf"
+            mrf_file = self.options["outfilename"]["value"] + runtime + "_00.mrf"
 
         # Read the first two rows to get column names and units
         with open(mrf_file, 'r') as file:

--- a/pytRIBS/shared/infile_mixin.py
+++ b/pytRIBS/shared/infile_mixin.py
@@ -195,40 +195,40 @@ class Infile:
             # MESH / INPUT FILES
             # ==================================================================================================
 
-            "inputdatafile": {"keyword": "INPUTDATAFILE:", "describe": "tMesh input file base name for Mesh files",
+            "inputdatafile": {"keyword": "INPUTDATAFILE:", "describe": "tMesh input file base name for Mesh files, see OPTMESHINPUT",
                               "value": None, "tags": ["mesh"], "section": 3, "subsection": "Mesh Generation"},
-            "pointfilename": {"keyword": "POINTFILENAME:", "describe": "tMesh input file name Points files",
+            "pointfilename": {"keyword": "POINTFILENAME:", "describe": "tMesh input file name Points files, see OPTMESHINPUT",
                               "value": None, "tags": ["mesh"], "section": 3, "subsection": "Mesh Generation"},
 
             # ==================================================================================================
             # GRID RESAMPLE
             # ==================================================================================================
 
-            "soiltablename": {"keyword": "SOILTABLENAME:", "describe": "Soil parameter reference table (*.sdt)",
+            "soiltablename": {"keyword": "SOILTABLENAME:", "describe": "Soil parameter reference table (*.sdt), see OPTSOILTYPE",
                               "value": None, "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
-            "soilmapname": {"keyword": "SOILMAPNAME:", "describe": "Soil texture ASCII grid (*.soi)", "value": None,
+            "soilmapname": {"keyword": "SOILMAPNAME:", "describe": "Soil texture ASCII grid (*.soi), see OPTSOILTYPE", "value": None,
                             "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
-            "landtablename": {"keyword": "LANDTABLENAME:", "describe": "Land use parameter reference table",
+            "landtablename": {"keyword": "LANDTABLENAME:", "describe": "Land use parameter reference table, see OPTLANDUSE",
                               "value": None, "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
-            "landmapname": {"keyword": "LANDMAPNAME:", "describe": "Land use ASCII grid (*.lan)", "value": None,
+            "landmapname": {"keyword": "LANDMAPNAME:", "describe": "Land use ASCII grid (*.lan), see OPTLANDUSE", "value": None,
                             "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
-            "gwaterfile": {"keyword": "GWATERFILE:", "describe": "Ground water ASCII grid (*iwt)", "value": None,
+            "gwaterfile": {"keyword": "GWATERFILE:", "describe": "Ground water ASCII grid (*iwt), see OPTGWFILE", "value": None,
                            "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
-            "demfile": {"keyword": "DEMFILE:", "describe": "DEM ASCII grid for sky and land view factors (*.dem)",
+            "demfile": {"keyword": "DEMFILE:", "describe": "DEM ASCII grid for sky and land view factors (*.dem), see OPTRADSHELT",
                         "value": None, "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
-            "rainfile": {"keyword": "RAINFILE:", "describe": "Base name of the radar ASCII grid", "value": None,
+            "rainfile": {"keyword": "RAINFILE:", "describe": "Base name of the radar ASCII grid, see RAINSOURCE", "value": None,
                          "tags": ["meterological"], "section": 3, "subsection": "Resampling Grids"},
-            "rainextension": {"keyword": "RAINEXTENSION:", "describe": "Extension for the radar ASCII grid",
+            "rainextension": {"keyword": "RAINEXTENSION:", "describe": "Extension for the radar ASCII grid, see RAINSOURCE",
                               "value": None, "tags": ["meterological"], "section": 3, "subsection": "Resampling Grids"},
-            "raindistribution": {"keyword": "RAINDISTRIBUTION:", "describe": "Precipitation distributed as provided or mean areal precipitation",
+            "raindistribution": {"keyword": "RAINDISTRIBUTION:", "describe": "Precipitation distributed as provided or mean areal precipitation, see RAINSOURCE",
                                  "value": 0, "tags": ["meterological"], "section": 3, "subsection": "Resampling Grids"},
             "depthtobedrock": {"keyword": "DEPTHTOBEDROCK:", "describe": "Uniform depth to bedrock (meters), see OPTBEDROCK",
                                "value": 15, "tags": ["hydro"], "section": 3, "subsection": "Resampling Grids"},
             "bedrockfile": {"keyword": "BEDROCKFILE:", "describe": "Bedrock depth ASCII grid (*.brd), see OPTBEDROCK",
                             "value": None, "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
-            "lugrid": {"keyword": "LUGRID:", "describe": "Land cover grid data file (*.gdf)", "value": None,
+            "lugrid": {"keyword": "LUGRID:", "describe": "Land cover grid data file (*.gdf), see OPTLANDUSE", "value": None,
                        "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
-            "scgrid": {"keyword": "SCGRID:", "describe": "Soil cover grid data file (*.gdf)", "value": None,
+            "scgrid": {"keyword": "SCGRID:", "describe": "Soil cover grid data file (*.gdf), see OPTSOILTYPE", "value": None,
                        "tags": ["spatial"], "section": 3, "subsection": "Resampling Grids"},
 
             # ==================================================================================================
@@ -248,11 +248,11 @@ class Infile:
             "centroidlong": {"keyword": "CENTROIDLONG:", "describe": "Longitude of the watershed centroid, used for solar position calculations (decimal degrees)",
                              "value": None, "tags": ["solar"], "section": 3, "subsection": "Meteorological Variables"},
             "hydrometstations": {"keyword": "HYDROMETSTATIONS:",
-                                 "describe": "Hydrometeorological station file (*.sdf)", "value": None,
+                                 "describe": "Hydrometeorological station file (*.sdf), see METDATAOPTION", "value": None,
                                  "tags": ["meterological"], "section": 3, "subsection": "Meteorological Data"},
-            "hydrometgrid": {"keyword": "HYDROMETGRID:", "describe": "Hydrometeorological grid data file (*.gdf)",
+            "hydrometgrid": {"keyword": "HYDROMETGRID:", "describe": "Hydrometeorological grid data file (*.gdf), see METDATAOPTION",
                              "value": None, "tags": ["meterological"], "section": 3, "subsection": "Meteorological Data"},
-            "gaugestations": {"keyword": "GAUGESTATIONS:", "describe": "Rain Gauge station file (*.sdf)",
+            "gaugestations": {"keyword": "GAUGESTATIONS:", "describe": "Rain Gauge station file (*.sdf), see RAINSOURCE",
                               "value": None, "tags": ["meterological"], "section": 3, "subsection": "Meteorological Data"},
 
             # ==================================================================================================
@@ -275,11 +275,11 @@ class Infile:
             # Module Input Files
             # ==================================================================================================
 
-            "respolygonid": {"keyword": "RESPOLYGONID:", "describe": "Path to file of node IDs representing reservoirs",
+            "respolygonid": {"keyword": "RESPOLYGONID:", "describe": "Path to file of node IDs representing reservoirs, see OPTRESERVOIR",
                              "value": None, "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
-            "resdata": {"keyword": "RESDATA:", "describe": "Path to file of elevation-discharge-storage information for each type of reservoir",
+            "resdata": {"keyword": "RESDATA:", "describe": "Path to file of elevation-discharge-storage information for each type of reservoir, see OPTRESERVOIR",
                         "value": None, "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
-            "snowfilename": {"keyword": "SNOWFILENAME:", "describe": "Snow parameter reference file (*.spf)",
+            "snowfilename": {"keyword": "SNOWFILENAME:", "describe": "Snow parameter reference file (*.spf), see OPTSNOW",
                              "value": None, "tags": ["meterological"], "section": 3, "subsection": "Module Input Files"},
 
             # ==================================================================================================

--- a/pytRIBS/shared/infile_mixin.py
+++ b/pytRIBS/shared/infile_mixin.py
@@ -259,10 +259,8 @@ class Infile:
             # OUTPUT DATA
             # ==================================================================================================
 
-            "outfilename": {"keyword": "OUTFILENAME:", "describe": "Base name of the tMesh and variable",
+            "outfilename": {"keyword": "OUTFILENAME:", "describe": "Filepath and base name of model outputs",
                             "value": None, "tags": ["output"], "section": 3, "subsection": "Output Data"},
-            "outhydrofilename": {"keyword": "OUTHYDROFILENAME:", "describe": "Base name for hydrograph output",
-                                 "value": None, "tags": ["output"], "section": 3, "subsection": "Output Data"},
             "nodeoutputlist": {"keyword": "NODEOUTPUTLIST:",
                                "describe": "Filename with Nodes for Dynamic Output (*.nol)", "value": None,
                                "tags": ["output"], "section": 3, "subsection": "Output Data"},

--- a/pytRIBS/shared/infile_mixin.py
+++ b/pytRIBS/shared/infile_mixin.py
@@ -23,7 +23,6 @@ class Infile:
         spatial   - input raster files and tables for bedrock, groundwater, landuse, and soil properties.
         meterological    -  options for meterological data
         output    - options and paths for model outputs
-        forecast - suite of options for forecast mode
         restart   - options for restart functionality
         parallel  - options for parallel functionality
 
@@ -56,13 +55,6 @@ class Infile:
                             "tags": ["time"], "section": 1, "subsection": "Time Variables"},
             "rainsearch": {"keyword": "RAINSEARCH:", "describe": "Rainfall search interval (hours)", "value": 24,
                            "tags": ["time"], "section": 1, "subsection": "Time Variables"},
-
-            "utcoffset": {"keyword": "UTCOFFSET:", "describe": "UTC (GMT) offset of the watershed centroid, used for solar position calculations (hours)",
-                          "value": None, "tags": ["time"], "section": 1, "subsection": "Solar Position Variables"},
-            "centroidlat": {"keyword": "CENTROIDLAT:", "describe": "Latitude of the watershed centroid, used for solar position calculations (decimal degrees)",
-                            "value": None, "tags": ["solar"], "section": 1, "subsection": "Solar Position Variables"},
-            "centroidlong": {"keyword": "CENTROIDLONG:", "describe": "Longitude of the watershed centroid, used for solar position calculations (decimal degrees)",
-                             "value": None, "tags": ["solar"], "section": 1, "subsection": "Solar Position Variables"},
 
             # ==================================================================================================
             # ROUTING PARAMETERS
@@ -228,6 +220,8 @@ class Infile:
                          "tags": ["meterological"], "section": 3, "subsection": "Resampling Grids"},
             "rainextension": {"keyword": "RAINEXTENSION:", "describe": "Extension for the radar ASCII grid",
                               "value": None, "tags": ["meterological"], "section": 3, "subsection": "Resampling Grids"},
+            "raindistribution": {"keyword": "RAINDISTRIBUTION:", "describe": "Precipitation distributed as provided or mean areal precipitation",
+                                 "value": 0, "tags": ["meterological"], "section": 3, "subsection": "Resampling Grids"},
             "depthtobedrock": {"keyword": "DEPTHTOBEDROCK:", "describe": "Uniform depth to bedrock (meters), see OPTBEDROCK",
                                "value": 15, "tags": ["hydro"], "section": 3, "subsection": "Resampling Grids"},
             "bedrockfile": {"keyword": "BEDROCKFILE:", "describe": "Bedrock depth ASCII grid (*.brd), see OPTBEDROCK",
@@ -247,6 +241,12 @@ class Infile:
                           "tags": ["meterological"], "section": 3, "subsection": "Meteorological Variables"},
             "preclapse": {"keyword": "PRECLAPSE:", "describe": "Precipitation lapse rate", "value": 0,
                           "tags": ["meterological"], "section": 3, "subsection": "Meteorological Variables"},
+            "utcoffset": {"keyword": "UTCOFFSET:", "describe": "UTC (GMT) offset of the watershed centroid, used for solar position calculations (hours)",
+                          "value": None, "tags": ["time"], "section": 3, "subsection": "Meteorological Variables"},
+            "centroidlat": {"keyword": "CENTROIDLAT:", "describe": "Latitude of the watershed centroid, used for solar position calculations (decimal degrees)",
+                            "value": None, "tags": ["solar"], "section": 3, "subsection": "Meteorological Variables"},
+            "centroidlong": {"keyword": "CENTROIDLONG:", "describe": "Longitude of the watershed centroid, used for solar position calculations (decimal degrees)",
+                             "value": None, "tags": ["solar"], "section": 3, "subsection": "Meteorological Variables"},
             "hydrometstations": {"keyword": "HYDROMETSTATIONS:",
                                  "describe": "Hydrometeorological station file (*.sdf)", "value": None,
                                  "tags": ["meterological"], "section": 3, "subsection": "Meteorological Data"},
@@ -283,36 +283,23 @@ class Infile:
                         "value": None, "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
             "snowfilename": {"keyword": "SNOWFILENAME:", "describe": "Snow parameter reference file (*.spf)",
                              "value": None, "tags": ["meterological"], "section": 3, "subsection": "Module Input Files"},
-            "channelconductivity": {"keyword": "CHANNELCONDUCTIVITY:", "describe": "Conductivity in channel for all methods (mm/hr)",
-                                    "value": 0, "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
-            "transientconductivity": {"keyword": "TRANSIENTCONDUCTIVITY:", "describe": "Conductivity in channel during transient period in (mm/hr)",
-                                      "value": 0, "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
-            "transienttime": {"keyword": "TRANSIENTTIME:", "describe": "Time until transient period ends (hours)", "value": 0,
-                              "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
-            "channelporosity": {"keyword": "CHANNELPOROSITY:", "describe": "Porosity in channel", "value": 0,
-                                "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
-            "chanporeindex": {"keyword": "CHANPOREINDEX:", "describe": "Channel pore index in channel", "value": 0,
-                              "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
-            "chanpsib": {"keyword": "CHANPSIB:", "describe": "Matric potential in channel", "value": 0,
-                         "tags": ["hydro"], "section": 3, "subsection": "Module Input Files"},
 
             # ==================================================================================================
-            # FORECAST MODE
+            # CHANNEL TRANSMISSION LOSSES
             # ==================================================================================================
-            "forecastmode": {"keyword": "FORECASTMODE:", "describe": "Rainfall Forecasting Mode Option", "value": 0,
-                             "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
-            "forecasttime": {"keyword": "FORECASTTIME:", "describe": "Forecast Time (hours from start)", "value": 0,
-                             "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
-            "forecastleadtime": {"keyword": "FORECASTLEADTIME:", "describe": "Forecast Lead Time (hours) ",
-                                 "value": 0, "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
-            "forecastlength": {"keyword": "FORECASTLENGTH:", "describe": "Forecast Window Length (hours)", "value": 0,
-                               "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
-            "forecastfile": {"keyword": "FORECASTFILE:", "describe": "Base name of the radar QPF grids",
-                             "value": None, "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
-            "climatology": {"keyword": "CLIMATOLOGY:", "describe": "Rainfall climatology (mm/hr)", "value": 0,
-                            "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
-            "raindistribution": {"keyword": "RAINDISTRIBUTION:", "describe": "Distributed or MAP radar rainfall",
-                                 "value": 0, "tags": ["forecast"], "section": 4, "subsection": "Rainfall Forecasting"},
+
+            "channelconductivity": {"keyword": "CHANNELCONDUCTIVITY:", "describe": "Conductivity in channel for all methods (mm/hr)",
+                                    "value": 0, "tags": ["hydro"], "section": 4, "subsection": "Channel Transmission Losses"},
+            "transientconductivity": {"keyword": "TRANSIENTCONDUCTIVITY:", "describe": "Conductivity in channel during transient period in (mm/hr)",
+                                      "value": 0, "tags": ["hydro"], "section": 4, "subsection": "Channel Transmission Losses"},
+            "transienttime": {"keyword": "TRANSIENTTIME:", "describe": "Time until transient period ends (hours)", "value": 0,
+                              "tags": ["hydro"], "section": 4, "subsection": "Channel Transmission Losses"},
+            "channelporosity": {"keyword": "CHANNELPOROSITY:", "describe": "Porosity in channel", "value": 0,
+                                "tags": ["hydro"], "section": 4, "subsection": "Channel Transmission Losses"},
+            "chanporeindex": {"keyword": "CHANPOREINDEX:", "describe": "Channel pore index in channel", "value": 0,
+                              "tags": ["hydro"], "section": 4, "subsection": "Channel Transmission Losses"},
+            "chanpsib": {"keyword": "CHANPSIB:", "describe": "Matric potential in channel", "value": 0,
+                         "tags": ["hydro"], "section": 4, "subsection": "Channel Transmission Losses"},
 
             # ==================================================================================================
             # RESTART MODE


### PR DESCRIPTION
This PR completes the alignment of the main tRIBS input file (`.in`) with the v6.0.0 model release. The bulk of the change is a reorganization of `infile_mixin.py`. The deprecated Rainfall Forecasting module has been removed entirely, the duplicate output base name has been dropped in favor of a single output name, and the solar-position and channel transmission-loss keywords have been regrouped.

## Technical Changes

**`pytRIBS/shared/infile_mixin.py`**
* Removed the Rainfall Forecasting module keywords: `FORECASTMODE`, `FORECASTTIME`, `FORECASTLEADTIME`, `FORECASTLENGTH`, `FORECASTFILE`, and `CLIMATOLOGY`.
* Moved the channel transmission-loss parameters (`CHANNELCONDUCTIVITY`, `TRANSIENTCONDUCTIVITY`, `TRANSIENTTIME`, `CHANNELPOROSITY`, `CHANPOREINDEX`, `CHANPSIB`) out of "Module Input Files" into their own Section 4 **Channel Transmission Losses** subsection.
* Removed the `OUTHYDROFILENAME` keyword (see Breaking Changes).
* Added `see <KEYWORD>` cross-references to the Section 3 file/parameter descriptions, pointing each input to the option that controls whether it is used (e.g., `SOILTABLENAME` → `OPTSOILTYPE`, `HYDROMETSTATIONS` → `METDATAOPTION`).

**`pytRIBS/results/read.py`**
* Repointed `get_qout_results` (`_Outlet.qout`) and `get_mrf_results` (`.mrf`) to construct their output filenames from `OUTFILENAME` instead of the removed `OUTHYDROFILENAME`. Suffix conventions are unchanged, so the readers continue to resolve the files tRIBS writes. Docstrings updated to match.

## Breaking Changes
  
* The following input-file keywords have been removed and will cause no harm if left in an existing `.in` file, but are no longer written or read by pytRIBS: `FORECASTMODE`, `FORECASTTIME`, `FORECASTLEADTIME`, `FORECASTLENGTH`, `FORECASTFILE`, `CLIMATOLOGY`, and `OUTHYDROFILENAME`.