### PR TITLE
Amend v0.7.4: Fix soil workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "PyWavelets>=1.8.0",
     "rasterio>=1.4.0",
     "requests>=2.32.3",
-    "rosetta-soil>=0.1.2,<0.3",
+    "rosetta-soil>=0.3,<0.4",
     "scikit-learn>=1.7.0",
     "scipy>=1.14.0",
     "shapely>=2.0.7",
@@ -38,7 +38,7 @@ dependencies = [
     "rioxarray>=0.17.0",
 ]
 version = "0.7.4"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [project.urls]
 Repository = "https://github.com/tRIBS-Model/pytRIBS"

--- a/pytRIBS/soil/soil.py
+++ b/pytRIBS/soil/soil.py
@@ -726,7 +726,10 @@ class SoilProcessor:
                 # Organize array for input into packag
                 data = [sg250_data[x, i, j] for x in np.arange(0, 6)]
                 soil_data = SoilData.from_iter([data])
-                mean, stdev, codes = rosetta(3, soil_data)  # apply Rosetta version 3
+                # estimate_type="log" returns log10(alpha), log10(npar), and log10(Ksat),
+                # which is what the 10** conversions below expect. Omitting it
+                # silently double-transforms Ks, psib, and m.
+                mean, stdev, codes = rosetta(3, soil_data, estimate_type="log")  # apply Rosetta version 3
                 theta_r[:, i, j] = [mean[0, 0], stdev[0, 0], codes[0]]
                 theta_s[:, i, j] = [mean[0, 1], stdev[0, 1], codes[0]]
                 # Convert ks from log10(cm/day) into mm/hr


### PR DESCRIPTION
#50 Pinned the rosetta-soil package to an older version that uses `from_array rather` than `from_iter` which is incompatible with pytRIBs v0.7.4. Updated pytRIBS workflow to specifically request rosetta outputs in log transformed units for compatibility.  